### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This tool finds and ports triple slash comments found in .NET repos but do not y
 This command will look for triple slash comments in APIs from System.IO* and System.Text* (except System.IO.Compression and System.IO.FileSystem), within the corefx and coreclr repos, then check if they are missing in the dotnet-api-docs repo, and if they are, then they get automatically added to the appropriate xml file:
 
 ```
-DocsPortingTool.exe -docs D:\dotnet-api-docs -include System.IO,System.Text -exclude System.IO.Compression,System.IO.FileSystem -save true -tripleslash D:\coreclr\bin\Product\Windows_NT.x64.Debug\IL\,D:\corefx\artifacts\bin\
+DocsPortingTool.exe -docs D:\dotnet-api-docs\xml -include System.IO,System.Text -exclude System.IO.Compression,System.IO.FileSystem -save true -tripleslash D:\coreclr\bin\Product\Windows_NT.x64.Debug\IL\,D:\corefx\artifacts\bin\
 ```
 
 ### Options:
@@ -18,7 +18,7 @@ DocsPortingTool.exe -docs D:\dotnet-api-docs -include System.IO,System.Text -exc
     folder path:    -docs                   Mandatory. The absolute directory path to the Docs repo.
 
                                                 Usage example:
-                                                    -docs %SourceRepos%\dotnet-api-docs
+                                                    -docs %SourceRepos%\dotnet-api-docs\xml
 
 
     string list:    -exclude                Optional. Comma separated list (no spaces) of specific .NET assemblies to ignore. Default is empty.


### PR DESCRIPTION
Without the `\xml` bit in the dotnet-api-docs repo the tool would not generate anything.
It wasn't until I started debugging the tool I found it needed the xml subdirectory.