### PR TITLE
Handle namespace and assembly separately

### DIFF
--- a/DocsPortingTool/Configuration.cs
+++ b/DocsPortingTool/Configuration.cs
@@ -14,8 +14,10 @@ namespace DocsPortingTool
             Docs,
             ExceptionCollisionThreshold,
             ExcludedAssemblies,
+            ExcludedNamespaces,
             ExcludedTypes,
             IncludedAssemblies,
+            IncludedNamespaces,
             IncludedTypes,
             Initial,
             PortExceptionsExisting,
@@ -46,6 +48,8 @@ namespace DocsPortingTool
 
         public HashSet<string> IncludedAssemblies { get; } = new HashSet<string>();
         public HashSet<string> ExcludedAssemblies { get; } = new HashSet<string>();
+        public HashSet<string> IncludedNamespaces { get; } = new HashSet<string>();
+        public HashSet<string> ExcludedNamespaces { get; } = new HashSet<string>();
         public HashSet<string> IncludedTypes { get; } = new HashSet<string>();
         public HashSet<string> ExcludedTypes { get; } = new HashSet<string>();
 
@@ -160,6 +164,28 @@ namespace DocsPortingTool
                             break;
                         }
 
+                    case Mode.ExcludedNamespaces:
+                        {
+                            string[] splittedArg = arg.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+
+                            if (splittedArg.Length > 0)
+                            {
+                                Log.Cyan("Excluded namespaces:");
+                                foreach (string ns in splittedArg)
+                                {
+                                    Log.Cyan($" - {ns}");
+                                    config.ExcludedNamespaces.Add(ns);
+                                }
+                            }
+                            else
+                            {
+                                Log.LogErrorPrintHelpAndExit("You must specify at least one namespace.");
+                            }
+
+                            mode = Mode.Initial;
+                            break;
+                        }
+
                     case Mode.ExcludedTypes:
                         {
                             string[] splittedArg = arg.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
@@ -198,6 +224,28 @@ namespace DocsPortingTool
                             else
                             {
                                 Log.LogErrorPrintHelpAndExit("You must specify at least one assembly.");
+                            }
+
+                            mode = Mode.Initial;
+                            break;
+                        }
+
+                    case Mode.IncludedNamespaces:
+                        {
+                            string[] splittedArg = arg.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+
+                            if (splittedArg.Length > 0)
+                            {
+                                Log.Cyan($"Included namespaces:");
+                                foreach (string ns in splittedArg)
+                                {
+                                    Log.Cyan($" - {ns}");
+                                    config.IncludedNamespaces.Add(ns);
+                                }
+                            }
+                            else
+                            {
+                                Log.LogErrorPrintHelpAndExit("You must specify at least one namespace.");
                             }
 
                             mode = Mode.Initial;
@@ -246,6 +294,10 @@ namespace DocsPortingTool
                                     mode = Mode.ExcludedAssemblies;
                                     break;
 
+                                case "-EXCLUDEDNAMESPACES":
+                                    mode = Mode.ExcludedNamespaces;
+                                    break;
+
                                 case "-EXCLUDEDTYPES":
                                     mode = Mode.ExcludedTypes;
                                     break;
@@ -258,6 +310,10 @@ namespace DocsPortingTool
 
                                 case "-INCLUDEDASSEMBLIES":
                                     mode = Mode.IncludedAssemblies;
+                                    break;
+
+                                case "-INCLUDEDNAMESPACES":
+                                    mode = Mode.IncludedNamespaces;
                                     break;
 
                                 case "-INCLUDEDTYPES":
@@ -486,26 +542,20 @@ namespace DocsPortingTool
 
             if (config.DirsDocsXml == null)
             {
-                Log.LogErrorPrintHelpAndExit("You must specify a path to the dotnet-api-docs xml folder with -docs.");
+                Log.LogErrorPrintHelpAndExit($"You must specify a path to the dotnet-api-docs xml folder with {nameof(Docs)}.");
             }
 
             if (config.DirsTripleSlashXmls.Count == 0)
             {
-                Log.LogErrorPrintHelpAndExit("You must specify at least one triple slash xml folder path with -tripleslash.");
+                Log.LogErrorPrintHelpAndExit($"You must specify at least one triple slash xml folder path with {nameof(TripleSlash)}.");
             }
 
             if (config.IncludedAssemblies.Count == 0)
             {
-                Log.LogErrorPrintHelpAndExit("You must specify at least one assembly with -include.");
+                Log.LogErrorPrintHelpAndExit($"You must specify at least one assembly with {nameof(IncludedAssemblies)}.");
             }
 
             return config;
-        }
-
-        // Hardcoded namespaces that need to be renamed to what MS Docs uses.
-        public static string ReplaceNamespace(string str)
-        {
-            return str.Replace("Microsoft.Data", "System.Data");
         }
 
         // Tries to parse the user argument string as boolean, and if it fails, exits the program.

--- a/DocsPortingTool/Docs/DocsCommentsContainer.cs
+++ b/DocsPortingTool/Docs/DocsCommentsContainer.cs
@@ -69,6 +69,11 @@ namespace DocsPortingTool.Docs
         {
             if (!Config.Save)
             {
+                Log.Line();
+                Log.Error("[No files were saved]");
+                Log.Warning($"Did you forget to specify '-{nameof(Config.Save)} true'?");
+                Log.Line();
+
                 return;
             }
 
@@ -143,7 +148,8 @@ namespace DocsPortingTool.Docs
 
             foreach (DirectoryInfo rootDir in Config.DirsDocsXml)
             {
-                foreach (string included in Config.IncludedAssemblies)
+                // Try to find folders with the names of assemblies AND namespaces (if the user specified any)
+                foreach (string included in Config.IncludedAssemblies.Concat(Config.IncludedNamespaces))
                 {
                     foreach (DirectoryInfo subDir in rootDir.EnumerateDirectories($"{included}*", SearchOption.TopDirectoryOnly))
                     {
@@ -183,7 +189,8 @@ namespace DocsPortingTool.Docs
                         foreach (DirectoryInfo subDir in rootDir.EnumerateDirectories("System*", SearchOption.AllDirectories))
                         {
                             if (!Configuration.ForbiddenDirectories.Contains(subDir.Name) &&
-                                Config.ExcludedAssemblies.Count(excluded => subDir.Name.StartsWith(excluded)) == 0 &&
+                                // Exclude any folder that starts with the excluded assemblies OR excluded namespaces
+                                Config.ExcludedAssemblies.Concat(Config.ExcludedNamespaces).Count(excluded => subDir.Name.StartsWith(excluded)) == 0 &&
                                 !subDir.Name.EndsWith(".Tests"))
                             {
                                 foreach (FileInfo fileInfo in subDir.EnumerateFiles("I*.xml", SearchOption.AllDirectories))
@@ -288,7 +295,7 @@ namespace DocsPortingTool.Docs
                 // included (and not exluded) types, but will not be used for EII, but rather as normal types whose comments should be ported
                 if (!addedAsInterface)
                 {
-                    foreach (string included in Config.IncludedAssemblies)
+                    foreach (string included in Config.IncludedAssemblies.Concat(Config.IncludedNamespaces))
                     {
                         if (docsType.AssemblyInfos.Count(x => x.AssemblyName.StartsWith(included)) > 0 ||
                             docsType.FullName.StartsWith(included))

--- a/DocsPortingTool/Log.cs
+++ b/DocsPortingTool/Log.cs
@@ -205,9 +205,13 @@ Options:
                                                     Usage example:
                                                         -TripleSlash %SourceRepos%\corefx\artifacts\bin\,%SourceRepos%\winforms\artifacts\bin\
 
-    -IncludedAssemblies     string list         Comma separated list (no spaces) of assemblies/namespaces to include.
+    -IncludedAssemblies     string list         Comma separated list (no spaces) of assemblies to include.
                                                     Usage example:
-                                                        -IncludedAssemblies System.IO,System.Runtime.Intrinsics
+                                                        -IncludedAssemblies System.IO,System.Runtime
+
+                                                IMPORTANT: 
+                                                Namespaces usually match the assembly name. There are some exceptions, like with types that live in
+                                                the System.Runtime assembly. For those cases, make sure to also specify the -IncludedNamespaces argument.
 
 
                                OPTIONAL
@@ -239,10 +243,20 @@ Options:
                                                     Usage example:
                                                         -ExcludedAssemblies System.IO.Compression,System.IO.Pipes
 
+    -ExcludedNamespaces     string list         Default is empty (does not exclude any namespaces from the specified assemblies).
+                                                Comma separated list (no spaces) of specific namespaces to exclude from the specified assemblies.
+                                                    Usage example:
+                                                        -ExcludedNamespaces System.Runtime.Intrinsics,System.Reflection.Metadata
+
     -ExcludedTypes          string list         Default is empty (does not ignore any types).
                                                 Comma separated list (no spaces) of names of types to ignore.
                                                     Usage example:
                                                         -ExcludedTypes ArgumentException,Stream
+
+    -IncludedNamespaces     string list         Default is empty (includes all namespaces from the specified assemblies).
+                                                Comma separated list (no spaces) of specific namespaces to include from the specified assemblies.
+                                                    Usage example:
+                                                        -IncludedNamespaces System,System.Data
 
     -IncludedTypes          string list         Default is empty (includes all types in the desired assemblies/namespaces).
                                                 Comma separated list (no spaces) of specific types to include.
@@ -349,9 +363,13 @@ Options:
     Example:
         DocsPortingTool \
             -Docs D:\dotnet-api-docs\xml \
-            -TripleSlash D:\runtime\artifacts\bin\coreclr\Windows_NT.x64.Release\IL,D:\runtime\artifacts\bin \
+            -TripleSlash D:\runtime\artifacts\bin \
             -IncludedAssemblies System.IO.FileSystem,System.Runtime.Intrinsics \
             -Save true
+");
+            Magenta(@"
+    Note:
+        If the names of your assemblies differ from the namespaces wheres your APIs live, specify the -IncludedNamespaces argument too.
 
             ");
         }

--- a/DocsPortingTool/Properties/launchSettings.json
+++ b/DocsPortingTool/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "DocsPortingTool": {
       "commandName": "Project",
-      "commandLineArgs": "-TripleSlash %SourceRepos\\runtime\\artifacts\\bin,%SourceRepos%\\runtime\\artifacts\\bin\\coreclr\\Windows_NT.x64.Release\\IL -Docs %SourceRepos%\\dotnet-api-docs\\xml -IncludedAssemblies System.IO -Save true -SkipInterfaceRemarks true -SkipExceptions true",
+      "commandLineArgs": "-TripleSlash D:\\runtime\\artifacts\\bin,D:\\runtime\\artifacts\\bin\\coreclr\\Windows_NT.x64.Release\\IL -Docs D:\\dotnet-api-docs\\xml -Save false -SkipInterfaceImplementations true -IncludedAssemblies System.Private.CoreLib -IncludedNamespaces System.Threading.Tasks -IncludedTypes Tasks",
       "environmentVariables": {
         "DOCS_IOT": "D:\\iot\\artifacts\\bin",
         "DOCS_CORECLR": "D:\\runtime\\artifacts\\bin\\coreclr\\Windows_NT.x64.Release\\IL\\",

--- a/DocsPortingTool/TripleSlash/TripleSlashCommentsContainer.cs
+++ b/DocsPortingTool/TripleSlash/TripleSlashCommentsContainer.cs
@@ -152,32 +152,27 @@ namespace DocsPortingTool.TripleSlash
                 {
                     TripleSlashMember member = new TripleSlashMember(xeMember, assembly);
 
-                    bool add = false;
-                    foreach (string included in Config.IncludedAssemblies)
+                    if (Config.IncludedAssemblies.Any(toInclude => member.Assembly.StartsWith(toInclude)) &&
+                        !Config.ExcludedAssemblies.Any(toExclude => member.Assembly.StartsWith(toExclude)))
                     {
-                        if (member.Assembly.StartsWith(included) ||
-                            member.Name.Substring(2).StartsWith(included) ||
-                            member.Namespace.StartsWith(included) ||
-                            Configuration.ReplaceNamespace(member.Assembly).StartsWith(included))
+                        bool add = false;
+                        if (Config.IncludedNamespaces.Count == 0)
                         {
+                            // No namespaces provided by the user means they
+                            // want to port everything from that assembly
                             add = true;
-                            break;
                         }
-                    }
-
-                    foreach (string excluded in Config.ExcludedAssemblies)
-                    {
-                        if (member.Assembly.StartsWith(excluded) || member.Name.Substring(2).StartsWith(excluded))
+                        else
                         {
-                            add = false;
-                            break;
+                            add = Config.IncludedNamespaces.Any(toInclude => member.Namespace.StartsWith(toInclude)) &&
+                                !Config.ExcludedNamespaces.Any(toExclude => member.Namespace.StartsWith(toExclude));
                         }
-                    }
 
-                    if (add)
-                    {
-                        totalAdded++;
-                        Members.Add(member);
+                        if (add)
+                        {
+                            totalAdded++;
+                            Members.Add(member);
+                        }
                     }
                 }
             }

--- a/DocsPortingTool/TripleSlash/TripleSlashException.cs
+++ b/DocsPortingTool/TripleSlash/TripleSlashException.cs
@@ -17,7 +17,7 @@ namespace DocsPortingTool.TripleSlash
             {
                 if (string.IsNullOrWhiteSpace(_cref))
                 {
-                    _cref = Configuration.ReplaceNamespace(XmlHelper.GetAttributeValue(XEException, "cref"));
+                    _cref = XmlHelper.GetAttributeValue(XEException, "cref");
                 }
                 return _cref;
             }

--- a/DocsPortingTool/TripleSlash/TripleSlashMember.cs
+++ b/DocsPortingTool/TripleSlash/TripleSlashMember.cs
@@ -20,10 +20,10 @@ namespace DocsPortingTool.TripleSlash
                 if (string.IsNullOrWhiteSpace(_namespace))
                 {
                     string[] splittedParenthesis = Name.Split('(', StringSplitOptions.RemoveEmptyEntries);
-                    string withoutParenthesisAndPrefix = splittedParenthesis[0].Substring(2);
+                    string withoutParenthesisAndPrefix = splittedParenthesis[0][2..]; // Exclude the "X:" prefix
                     string[] splittedDots = withoutParenthesisAndPrefix.Split('.', StringSplitOptions.RemoveEmptyEntries);
 
-                    _namespace = Configuration.ReplaceNamespace(string.Join('.', splittedDots.Take(splittedDots.Length - 1)));
+                    _namespace = string.Join('.', splittedDots.Take(splittedDots.Length - 1));
                 }
 
                 return _namespace;
@@ -31,13 +31,16 @@ namespace DocsPortingTool.TripleSlash
         }
 
         private string? _name;
+        /// <summary>
+        /// The API DocId.
+        /// </summary>
         public string Name
         {
             get
             {
                 if (_name == null)
                 {
-                    _name = Configuration.ReplaceNamespace(XmlHelper.GetAttributeValue(XEMember, "name"));
+                    _name = XmlHelper.GetAttributeValue(XEMember, "name");
                 }
                 return _name;
             }

--- a/Tests/TestData.cs
+++ b/Tests/TestData.cs
@@ -7,7 +7,12 @@ namespace DocsPortingTool.Tests
     {
         private string TestDataRootDir => @"..\..\..\TestData";
 
+        public const string TestAssembly = "MyAssembly";
+        public const string TestNamespace = "MyNamespace";
+        public const string TestType = "MyType";
+
         public string Assembly { get; private set; }
+        public string Namespace { get; private set; }
         public string Type { get; private set; }
         public DirectoryInfo TripleSlash { get; private set; }
         public DirectoryInfo Docs { get; private set; }
@@ -21,16 +26,20 @@ namespace DocsPortingTool.Tests
         /// <summary>Docs file with the interface from which the type inherits.</summary>
         public string InterfaceFilePath { get; private set; }
 
-        public TestData(TestDirectory tempDir, string testDataDir, string assemblyName = "MyAssembly", string typeName = "MyType", bool includeInterface = false)
+        public TestData(TestDirectory tempDir, string testDataDir, string assemblyName, string namespaceName, string typeName, bool skipInterfaceImplementations = true)
         {
+            Assert.False(string.IsNullOrWhiteSpace(assemblyName));
+            Assert.False(string.IsNullOrWhiteSpace(typeName));
+
             Assembly = assemblyName;
+            Namespace = string.IsNullOrEmpty(namespaceName) ? assemblyName : namespaceName;
             Type = typeName;
 
             TripleSlash = tempDir.CreateSubdirectory("TripleSlash");
-            DirectoryInfo tsAssemblyDir = TripleSlash.CreateSubdirectory(assemblyName);
+            DirectoryInfo tsAssemblyDir = TripleSlash.CreateSubdirectory(Assembly);
 
             Docs = tempDir.CreateSubdirectory("Docs");
-            DirectoryInfo docsAssemblyDir = Docs.CreateSubdirectory(assemblyName);
+            DirectoryInfo docsAssemblyDir = Docs.CreateSubdirectory(Namespace);
 
             string testDataPath = Path.Combine(TestDataRootDir, testDataDir);
 
@@ -42,8 +51,8 @@ namespace DocsPortingTool.Tests
             Assert.True(File.Exists(docsOriginFilePath));
             Assert.True(File.Exists(docsOriginExpectedFilePath));
 
-            OriginalFilePath = Path.Combine(tsAssemblyDir.FullName, $"{typeName}.xml");
-            ActualFilePath = Path.Combine(docsAssemblyDir.FullName, $"{typeName}.xml");
+            OriginalFilePath = Path.Combine(tsAssemblyDir.FullName, $"{Type}.xml");
+            ActualFilePath = Path.Combine(docsAssemblyDir.FullName, $"{Type}.xml");
             ExpectedFilePath = Path.Combine(tempDir.FullPath, "DocsExpected.xml");
 
             File.Copy(tsOriginFilePath, OriginalFilePath);
@@ -54,7 +63,7 @@ namespace DocsPortingTool.Tests
             Assert.True(File.Exists(ActualFilePath));
             Assert.True(File.Exists(ExpectedFilePath));
 
-            if (includeInterface)
+            if (!skipInterfaceImplementations)
             {
                 string interfaceFilePath = Path.Combine(testDataPath, "DocsInterface.xml");
                 Assert.True(File.Exists(interfaceFilePath));

--- a/Tests/TestData/AssemblyAndNamespaceDifferent/DocsExpected.xml
+++ b/Tests/TestData/AssemblyAndNamespaceDifferent/DocsExpected.xml
@@ -1,0 +1,34 @@
+﻿<Type Name="MyType" FullName="MyNamespace.MyType">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyType" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>This is the summary of MyNamespace.MyType. The namespace is not the same as the assembly.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyMethod">
+      <MemberSignature Language="DocId" Value="M:MyNamespace.MyMethod" />
+      <MemberType>Method</MemberType>
+      <Implements />
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>This is the summary of MyNamespace.MyMethod. The namespace is not the same as the assembly.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/TestData/AssemblyAndNamespaceDifferent/DocsOriginal.xml
+++ b/Tests/TestData/AssemblyAndNamespaceDifferent/DocsOriginal.xml
@@ -1,0 +1,34 @@
+﻿<Type Name="MyType" FullName="MyNamespace.MyType">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyType" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyMethod">
+      <MemberSignature Language="DocId" Value="M:MyNamespace.MyMethod" />
+      <MemberType>Method</MemberType>
+      <Implements />
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/TestData/AssemblyAndNamespaceDifferent/TSOriginal.xml
+++ b/Tests/TestData/AssemblyAndNamespaceDifferent/TSOriginal.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0"?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name="T:MyNamespace.MyType">
+      <summary>This is the summary of MyNamespace.MyType. The namespace is not the same as the assembly.</summary>
+    </member>
+    <member name="M:MyNamespace.MyMethod">
+      <summary>This is the summary of MyNamespace.MyMethod. The namespace is not the same as the assembly.</summary>
+    </member>
+  </members>
+</doc>

--- a/Tests/TestData/AssemblyAndNamespaceSame/DocsExpected.xml
+++ b/Tests/TestData/AssemblyAndNamespaceSame/DocsExpected.xml
@@ -1,0 +1,34 @@
+﻿<Type Name="MyType" FullName="MyAssembly.MyType">
+  <TypeSignature Language="DocId" Value="T:MyAssembly.MyType" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>This is the summary of MyAssembly.MyType. The namespace is the same as the assembly.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyMethod">
+      <MemberSignature Language="DocId" Value="M:MyAssembly.MyMethod" />
+      <MemberType>Method</MemberType>
+      <Implements />
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>This is the summary of MyAssembly.MyMethod. The namespace is the same as the assembly.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/TestData/AssemblyAndNamespaceSame/DocsOriginal.xml
+++ b/Tests/TestData/AssemblyAndNamespaceSame/DocsOriginal.xml
@@ -1,0 +1,34 @@
+﻿<Type Name="MyType" FullName="MyAssembly.MyType">
+  <TypeSignature Language="DocId" Value="T:MyAssembly.MyType" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyMethod">
+      <MemberSignature Language="DocId" Value="M:MyAssembly.MyMethod" />
+      <MemberType>Method</MemberType>
+      <Implements />
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/TestData/AssemblyAndNamespaceSame/TSOriginal.xml
+++ b/Tests/TestData/AssemblyAndNamespaceSame/TSOriginal.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0"?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name="T:MyAssembly.MyType">
+      <summary>This is the summary of MyAssembly.MyType. The namespace is the same as the assembly.</summary>
+    </member>
+    <member name="M:MyAssembly.MyMethod">
+      <summary>This is the summary of MyAssembly.MyMethod. The namespace is the same as the assembly.</summary>
+    </member>
+  </members>
+</doc>


### PR DESCRIPTION
Most namespaces have the same name as their assembly. There are a few cases though, where this is not the case. For those cases, the tool was not able to detect new comments easily.

This change fixes the problem by adding a new couple of arguments: `-IncludedNamespaces` and `-ExcludedNamespaces`, which can be optionally specified by the user if the assembly is different than the namespace.

If not explicitly specified, then the tool will assume the namespace is the same as the assembly name.