### PR TITLE
Assembly namespace bug fix

### DIFF
--- a/DocsPortingTool/Analyzer.cs
+++ b/DocsPortingTool/Analyzer.cs
@@ -69,11 +69,6 @@ namespace DocsPortingTool
         // Tries to find a triple slash element from which to port documentation for the specified Docs type.
         private void PortMissingCommentsForType(DocsType dTypeToUpdate)
         {
-            if (!CanAnalyzeAPI(dTypeToUpdate))
-            {
-                return;
-            }
-
             TripleSlashMember tsTypeToPort = TripleSlashComments.Members.FirstOrDefault(x => x.Name == dTypeToUpdate.DocIdEscaped);
             if (tsTypeToPort != null)
             {
@@ -96,12 +91,8 @@ namespace DocsPortingTool
         // Tries to find a triple slash element from which to port documentation for the specified Docs member.
         private void PortMissingCommentsForMember(DocsMember dMemberToUpdate)
         {
-            if (!CanAnalyzeAPI(dMemberToUpdate))
-            {
-                return;
-            }
-
-            TripleSlashMember tsMemberToPort = TripleSlashComments.Members.FirstOrDefault(x => x.Name == dMemberToUpdate.DocIdEscaped);
+            string docId = dMemberToUpdate.DocIdEscaped;
+            TripleSlashMember tsMemberToPort = TripleSlashComments.Members.FirstOrDefault(x => x.Name == docId);
             TryGetEIIMember(dMemberToUpdate, out DocsMember? interfacedMember);
 
             if (tsMemberToPort != null || interfacedMember != null)
@@ -705,80 +696,6 @@ namespace DocsPortingTool
             return string.IsNullOrWhiteSpace(s) || s == Configuration.ToBeAdded;
         }
 
-        private bool CanAnalyzeAPI(DocsAPI api)
-        {
-            bool result = IsTypeAllowed(api);
-            if (result)
-            {
-                foreach (DocsAssemblyInfo apiAssembly in api.AssemblyInfos)
-                {
-                    foreach (string excluded in Config.ExcludedAssemblies)
-                    {
-                        if (apiAssembly.AssemblyName.StartsWith(excluded))
-                        {
-                            return false; // No more analysis required
-                        }
-                    }
-
-                    foreach (string included in Config.IncludedAssemblies)
-                    {
-                        if (apiAssembly.AssemblyName.StartsWith(included))
-                        {
-                            result = true; // Almost done, need to check types if needed
-                            break;
-                        }
-                    }
-                }
-            }
-
-            return result;
-        }
-
-        private bool IsTypeAllowed(DocsAPI api)
-        {
-            // All types are allowed
-            if (Config.ExcludedTypes.Count() == 0 &&
-                Config.IncludedTypes.Count() == 0)
-            {
-                return true;
-            }
-
-            string typeName;
-            string typeFullName;
-
-            if (api is DocsType type)
-            {
-                typeName = type.Name;
-                typeFullName = type.FullName;
-            }
-            else if (api is DocsMember member)
-            {
-                typeName = member.ParentType.Name;
-                typeFullName = member.ParentType.FullName;
-            }
-            else
-            {
-                throw new InvalidCastException();
-            }
-
-            if (Config.ExcludedTypes.Count() > 0)
-            {
-                if (Config.ExcludedTypes.Contains(typeName) || Config.ExcludedTypes.Contains(typeFullName))
-                {
-                    return false;
-                }
-            }
-            if (Config.IncludedTypes.Count() > 0)
-            {
-                if (Config.IncludedTypes.Contains(typeName) || Config.IncludedTypes.Contains(typeFullName))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         /// <summary>
         /// Standard formatted print message for a modified element.
         /// </summary>
@@ -939,21 +856,21 @@ namespace DocsPortingTool
             Log.Info($"Total modified files: {ModifiedFiles.Count}");
             foreach (string file in ModifiedFiles)
             {
-                Log.Warning($"    - {file}");
+                Log.Success($"    - {file}");
             }
 
             Log.Line();
             Log.Info($"Total modified types: {ModifiedTypes.Count}");
             foreach (string type in ModifiedTypes)
             {
-                Log.Warning($"    - {type}");
+                Log.Success($"    - {type}");
             }
 
             Log.Line();
             Log.Info($"Total modified APIs: {ModifiedAPIs.Count}");
             foreach (string api in ModifiedAPIs)
             {
-                Log.Warning($"    - {api}");
+                Log.Success($"    - {api}");
             }
 
             Log.Line();
@@ -967,12 +884,12 @@ namespace DocsPortingTool
             Log.Info($"Total added exceptions: {AddedExceptions.Count}");
             foreach (string exception in AddedExceptions)
             {
-                Log.Warning($"    - {exception}");
+                Log.Success($"    - {exception}");
             }
 
             Log.Line();
             Log.Info(false, "Total modified individual elements: ");
-            Log.Warning($"{TotalModifiedIndividualElements}");
+            Log.Success($"{TotalModifiedIndividualElements}");
         }
     }
 }

--- a/DocsPortingTool/Docs/DocsAssemblyInfo.cs
+++ b/DocsPortingTool/Docs/DocsAssemblyInfo.cs
@@ -32,5 +32,7 @@ namespace DocsPortingTool.Docs
         {
             XEAssemblyInfo = xeAssemblyInfo;
         }
+
+        public override string ToString() => AssemblyName;
     }
 }

--- a/Tests/TestData/Remarks_WithEII_NoInterfaceRemarks/DocsExpected.xml
+++ b/Tests/TestData/Remarks_WithEII_NoInterfaceRemarks/DocsExpected.xml
@@ -1,5 +1,5 @@
-﻿<Type Name="MyType" FullName="MyNamespace.MyType">
-  <TypeSignature Language="DocId" Value="T:MyNamespace.MyType" />
+﻿<Type Name="MyType" FullName="MyAssembly.MyType">
+  <TypeSignature Language="DocId" Value="T:MyAssembly.MyType" />
   <AssemblyInfo>
     <AssemblyName>MyAssembly</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
@@ -19,14 +19,14 @@
 
 ## Remarks
 
-These are the type remarks. They also have a cref link: <xref:MyNamespace.MyType.MyMethod()>.
+These are the type remarks. They also have a cref link: <xref:MyAssembly.MyType.MyMethod()>.
 
           ]]></format>
     </remarks>
   </Docs>
   <Members>
     <Member MemberName="MyMethod">
-      <MemberSignature Language="DocId" Value="M:MyNamespace.MyType.MyMethod" />
+      <MemberSignature Language="DocId" Value="M:MyAssembly.MyType.MyMethod" />
       <MemberType>Method</MemberType>
       <Implements />
       <AssemblyInfo>
@@ -51,7 +51,7 @@ These are the method remarks. They are pointing to a param: `myParam`.
       </Docs>
     </Member>
     <Member MemberName="MyInterfaceMethod">
-      <MemberSignature Language="DocId" Value="M:MyNamespace.MyType.MyInterfaceMethod" />
+      <MemberSignature Language="DocId" Value="M:MyAssembly.MyType.MyInterfaceMethod" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.IMyInterface.MyInterfaceMethod</InterfaceMember>
@@ -70,7 +70,7 @@ These are the method remarks. They are pointing to a param: `myParam`.
       </Docs>
     </Member>
     <Member MemberName="System.IMyInterface.MyInterfaceMethod">
-      <MemberSignature Language="DocId" Value="M:MyNamespace.MyType.System#IMyInterface#MyInterfaceMethod" />
+      <MemberSignature Language="DocId" Value="M:MyAssembly.MyType.System#IMyInterface#MyInterfaceMethod" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.IMyInterface.MyInterfaceMethod</InterfaceMember>
@@ -91,7 +91,7 @@ These are the method remarks. They are pointing to a param: `myParam`.
 
 ## Remarks
 
-This member is an explicit interface member implementation. It can be used only when the <xref:MyNamespace.MyType> instance is cast to an <xref:System.IMyInterface> interface.
+This member is an explicit interface member implementation. It can be used only when the <xref:MyAssembly.MyType> instance is cast to an <xref:System.IMyInterface> interface.
 
           ]]></format>
         </remarks>

--- a/Tests/TestData/Remarks_WithEII_NoInterfaceRemarks/DocsOriginal.xml
+++ b/Tests/TestData/Remarks_WithEII_NoInterfaceRemarks/DocsOriginal.xml
@@ -1,5 +1,5 @@
-﻿<Type Name="MyType" FullName="MyNamespace.MyType">
-  <TypeSignature Language="DocId" Value="T:MyNamespace.MyType" />
+﻿<Type Name="MyType" FullName="MyAssembly.MyType">
+  <TypeSignature Language="DocId" Value="T:MyAssembly.MyType" />
   <AssemblyInfo>
     <AssemblyName>MyAssembly</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
@@ -18,7 +18,7 @@
   </Docs>
   <Members>
     <Member MemberName="MyMethod">
-      <MemberSignature Language="DocId" Value="M:MyNamespace.MyType.MyMethod" />
+      <MemberSignature Language="DocId" Value="M:MyAssembly.MyType.MyMethod" />
       <MemberType>Method</MemberType>
       <Implements />
       <AssemblyInfo>
@@ -35,7 +35,7 @@
       </Docs>
     </Member>
     <Member MemberName="MyInterfaceMethod">
-      <MemberSignature Language="DocId" Value="M:MyNamespace.MyType.MyInterfaceMethod" />
+      <MemberSignature Language="DocId" Value="M:MyAssembly.MyType.MyInterfaceMethod" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.IMyInterface.MyInterfaceMethod</InterfaceMember>
@@ -54,7 +54,7 @@
       </Docs>
     </Member>
     <Member MemberName="System.IMyInterface.MyInterfaceMethod">
-      <MemberSignature Language="DocId" Value="M:MyNamespace.MyType.System#IMyInterface#MyInterfaceMethod" />
+      <MemberSignature Language="DocId" Value="M:MyAssembly.MyType.System#IMyInterface#MyInterfaceMethod" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.IMyInterface.MyInterfaceMethod</InterfaceMember>

--- a/Tests/TestData/Remarks_WithEII_NoInterfaceRemarks/TSOriginal.xml
+++ b/Tests/TestData/Remarks_WithEII_NoInterfaceRemarks/TSOriginal.xml
@@ -4,11 +4,11 @@
     <name>MyAssembly</name>
   </assembly>
   <members>
-    <member name="T:MyNamespace.MyType">
+    <member name="T:MyAssembly.MyType">
       <summary>This is the type summary.</summary>
-      <remarks>These are the type remarks. They also have a cref link: <see cref="M:MyNamespace.MyType.MyMethod()" />.</remarks>
+      <remarks>These are the type remarks. They also have a cref link: <see cref="M:MyAssembly.MyType.MyMethod()" />.</remarks>
     </member>
-    <member name="M:MyNamespace.MyType.MyMethod">
+    <member name="M:MyAssembly.MyType.MyMethod">
       <summary>This is the method summary.</summary>
       <remarks>These are the method remarks. They are pointing to a param: <paramref name="myParam" />.</remarks>
     </member>


### PR DESCRIPTION
Fix bug preventing to find all cases of types that live in namespaces different than their assemblies.

Simplify code so that verification tasks for included/excluded items are not done more than once.

Cleanup.

Make sure one of the sets of EII test files has assembly = namespace. The other one will remain with assembly != namespace.