### PR TITLE
Don't add missing remarks

### DIFF
--- a/DocsPortingTool/Analyzer.cs
+++ b/DocsPortingTool/Analyzer.cs
@@ -51,6 +51,12 @@ namespace DocsPortingTool
             DocsComments.Save();
         }
 
+        // Checks if the passed string is considered "empty" according to the Docs repo rules.
+        internal static bool IsEmpty(string? s)
+        {
+            return string.IsNullOrWhiteSpace(s) || s == Configuration.ToBeAdded;
+        }
+
         private void PortMissingComments()
         {
             Log.Info("Looking for triple slash comments that can be ported...");
@@ -691,12 +697,6 @@ namespace DocsPortingTool
             }
 
             return created;
-        }
-
-        // Checks if the passed string is considered "empty" according to the Docs repo rules.
-        private bool IsEmpty(string? s)
-        {
-            return string.IsNullOrWhiteSpace(s) || s == Configuration.ToBeAdded;
         }
 
         /// <summary>

--- a/DocsPortingTool/Docs/DocsAPI.cs
+++ b/DocsPortingTool/Docs/DocsAPI.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -182,11 +183,11 @@ namespace DocsPortingTool.Docs
 
         protected string GetNodesInPlainText(string name)
         {
-            if (TryGetElement(name, out XElement element))
+            if (TryGetElement(name, addIfMissing: false, out XElement? element))
             {
                 if (name == "remarks")
                 {
-                    XElement formatElement = element.Element("format");
+                    XElement? formatElement = element.Element("format");
                     if (formatElement != null)
                     {
                         element = formatElement;
@@ -198,37 +199,36 @@ namespace DocsPortingTool.Docs
             return string.Empty;
         }
 
-        protected void SaveFormattedAsXml(string name, string value)
+        protected void SaveFormattedAsXml(string name, string value, bool addIfMissing)
         {
-            if (TryGetElement(name, out XElement element))
+            if (TryGetElement(name, addIfMissing, out XElement? element))
             {
                 XmlHelper.SaveFormattedAsXml(element, value);
                 Changed = true;
             }
         }
 
-        protected void SaveFormattedAsMarkdown(string name, string value)
+        protected void SaveFormattedAsMarkdown(string name, string value, bool addIfMissing, bool isMember)
         {
-            if (TryGetElement(name, out XElement element))
+            if (TryGetElement(name, addIfMissing, out XElement? element))
             {
-                XmlHelper.SaveFormattedAsMarkdown(element, value);
+                XmlHelper.SaveFormattedAsMarkdown(element, value, isMember);
                 Changed = true;
             }
         }
 
-        // Returns true if the element existed, false if it had to be created with "To be added." as value.
-        private bool TryGetElement(string name, out XElement element)
+        // Returns true if the element existed or had to be created with "To be added." as value. Returns false the element was not found and a new one was not created.
+        private bool TryGetElement(string name, bool addIfMissing, [NotNullWhen(returnValue: true)] out XElement? element)
         {
             element = Docs.Element(name);
 
-            if (element == null)
+            if (element == null && addIfMissing)
             {
                 element = new XElement(name);
                 XmlHelper.AddChildFormattedAsXml(Docs, element, Configuration.ToBeAdded);
-                return false;
             }
 
-            return true;
+            return element != null;
         }
     }
 }

--- a/DocsPortingTool/Docs/DocsMember.cs
+++ b/DocsPortingTool/Docs/DocsMember.cs
@@ -115,7 +115,14 @@ namespace DocsPortingTool.Docs
             }
             set
             {
-                SaveFormattedAsXml("returns", value);
+                if (ReturnType != "System.Void")
+                {
+                    SaveFormattedAsXml("returns", value, addIfMissing: false);
+                }
+                else
+                {
+                    Log.Warning($"Attempted to save a returns item for a method that returns System.Void: {DocIdEscaped}");
+                }
             }
         }
 
@@ -127,7 +134,7 @@ namespace DocsPortingTool.Docs
             }
             set
             {
-                SaveFormattedAsXml("summary", value);
+                SaveFormattedAsXml("summary", value, addIfMissing: true);
             }
         }
 
@@ -139,7 +146,7 @@ namespace DocsPortingTool.Docs
             }
             set
             {
-                SaveFormattedAsMarkdown("remarks", value);
+                SaveFormattedAsMarkdown("remarks", value, addIfMissing: !Analyzer.IsEmpty(value), isMember: true);
             }
         }
 
@@ -151,7 +158,14 @@ namespace DocsPortingTool.Docs
             }
             set
             {
-                SaveFormattedAsXml("value", value);
+                if (MemberType == "Property")
+                {
+                    SaveFormattedAsXml("value", value, addIfMissing: true);
+                }
+                else
+                {
+                    Log.Warning($"Attempted to save a value element for an API that is not a property: {DocIdEscaped}");
+                }
             }
         }
 

--- a/DocsPortingTool/Docs/DocsType.cs
+++ b/DocsPortingTool/Docs/DocsType.cs
@@ -160,7 +160,7 @@ namespace DocsPortingTool.Docs
             }
             set
             {
-                SaveFormattedAsXml("summary", value);
+                SaveFormattedAsXml("summary", value, addIfMissing: true);
             }
         }
 
@@ -172,7 +172,7 @@ namespace DocsPortingTool.Docs
             }
             set
             {
-                SaveFormattedAsMarkdown("remarks", value);
+                SaveFormattedAsMarkdown("remarks", value, addIfMissing: !Analyzer.IsEmpty(value), isMember: false);
             }
         }
 

--- a/DocsPortingTool/XmlHelper.cs
+++ b/DocsPortingTool/XmlHelper.cs
@@ -134,7 +134,7 @@ namespace DocsPortingTool
             return string.Join("", element.Nodes()).Trim();
         }
 
-        public static void SaveFormattedAsMarkdown(XElement element, string newValue)
+        public static void SaveFormattedAsMarkdown(XElement element, string newValue, bool isMember)
         {
             if (element == null)
             {
@@ -157,7 +157,9 @@ namespace DocsPortingTool
                 remarksTitle = "## Remarks\r\n\r\n";
             }
 
-            xeFormat.ReplaceAll(new XCData("\r\n\r\n" + remarksTitle + updatedValue + "\r\n\r\n          "));
+            string spaces = isMember ? "          " : "      ";
+
+            xeFormat.ReplaceAll(new XCData("\r\n\r\n" + remarksTitle + updatedValue + "\r\n\r\n" + spaces));
 
             // Attribute at the end, otherwise it would be replaced by ReplaceAll
             xeFormat.SetAttributeValue("type", "text/markdown");
@@ -165,7 +167,7 @@ namespace DocsPortingTool
             element.Add(xeFormat);
         }
 
-        public static void AddChildFormattedAsMarkdown(XElement parent, XElement child, string childValue)
+        public static void AddChildFormattedAsMarkdown(XElement parent, XElement child, string childValue, bool isMember)
         {
             if (parent == null)
             {
@@ -179,7 +181,7 @@ namespace DocsPortingTool
                 throw new ArgumentNullException(nameof(child));
             }
 
-            SaveFormattedAsMarkdown(child, childValue);
+            SaveFormattedAsMarkdown(child, childValue, isMember);
             parent.Add(child);
         }
 

--- a/Tests/TestData/DontAddMissingRemarks/DocsExpected.xml
+++ b/Tests/TestData/DontAddMissingRemarks/DocsExpected.xml
@@ -1,0 +1,56 @@
+﻿<Type Name="MyEnum" FullName="MyNamespace.MyEnum">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyEnum" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>This is the enum type summary.</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+This is the enum type remark.
+
+      ]]></format>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyOption0">
+      <MemberSignature Language="DocId" Value="F:MyNamespace.MyEnum.MyOption0" />
+      <MemberType>Field</MemberType>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <MenmberValue>0</MenmberValue>
+      <Docs>
+        <summary>This is the first option of MyEnum. Notice it has no remark.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="MyOption1">
+      <MemberSignature Language="DocId" Value="F:MyNamespace.MyEnum.MyOption1" />
+      <MemberType>Field</MemberType>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <MenmberValue>1</MenmberValue>
+      <Docs>
+        <summary>This is the second option of MyEnum. Notice it has a remark.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+This is the second option remark.
+
+          ]]></format>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/TestData/DontAddMissingRemarks/DocsOriginal.xml
+++ b/Tests/TestData/DontAddMissingRemarks/DocsOriginal.xml
@@ -1,0 +1,39 @@
+﻿<Type Name="MyEnum" FullName="MyNamespace.MyEnum">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyEnum" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyOption0">
+      <MemberSignature Language="DocId" Value="F:MyNamespace.MyEnum.MyOption0" />
+      <MemberType>Field</MemberType>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <MenmberValue>0</MenmberValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="MyOption1">
+      <MemberSignature Language="DocId" Value="F:MyNamespace.MyEnum.MyOption1" />
+      <MemberType>Field</MemberType>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <MenmberValue>1</MenmberValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/TestData/DontAddMissingRemarks/TSOriginal.xml
+++ b/Tests/TestData/DontAddMissingRemarks/TSOriginal.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0"?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name="T:MyNamespace.MyEnum">
+      <summary>This is the enum type summary.</summary>
+      <remarks>This is the enum type remark.</remarks>
+    </member>
+    <member name="F:MyNamespace.MyEnum.MyOption0">
+      <summary>This is the first option of MyEnum. Notice it has no remark.</summary>
+    </member>
+    <member name="F:MyNamespace.MyEnum.MyOption1">
+      <summary>This is the second option of MyEnum. Notice it has a remark.</summary>
+      <remarks>This is the second option remark.</remarks>
+    </member>
+  </members>
+</doc>

--- a/Tests/TestData/Remarks_NoEII_NoInterfaceRemarks/DocsExpected.xml
+++ b/Tests/TestData/Remarks_NoEII_NoInterfaceRemarks/DocsExpected.xml
@@ -17,7 +17,7 @@
 
 These are the type remarks. They also have a cref link: <xref:MyNamespace.MyType.MyMethod()>.
 
-          ]]></format>
+      ]]></format>
     </remarks>
   </Docs>
   <Members>

--- a/Tests/TestData/Remarks_WithEII_NoInterfaceRemarks/DocsExpected.xml
+++ b/Tests/TestData/Remarks_WithEII_NoInterfaceRemarks/DocsExpected.xml
@@ -21,7 +21,7 @@
 
 These are the type remarks. They also have a cref link: <xref:MyAssembly.MyType.MyMethod()>.
 
-          ]]></format>
+      ]]></format>
     </remarks>
   </Docs>
   <Members>

--- a/Tests/TestData/Remarks_WithEII_WithInterfaceRemarks/DocsExpected.xml
+++ b/Tests/TestData/Remarks_WithEII_WithInterfaceRemarks/DocsExpected.xml
@@ -21,7 +21,7 @@
 
 These are the type remarks. They also have a cref link: <xref:MyNamespace.MyType.MyMethod()>.
 
-          ]]></format>
+      ]]></format>
     </remarks>
   </Docs>
   <Members>

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -14,6 +14,12 @@ namespace DocsPortingTool.Tests
         }
 
         [Fact]
+        public void Port_DontAddMissingRemarks()
+        {
+            Port("DontAddMissingRemarks");
+        }
+
+        [Fact]
         // Verifies porting of APIs living in namespaces whose name match their assembly.
         public void Port_AssemblyAndNamespaceSame()
         {


### PR DESCRIPTION
There are certain API elements (types or members) that do not have a remarks item by default in Docs xmls. Currently, the tool automatically adds it if it's missing, but it shouldn't.

The logic has been modified so that the remarks item only gets added if there is a remarks section in the triple slash xml for that same API element.

Added unit tests to verify we don't add a remarks item every time, but only if a remarks item is incoming from triple slash.

I also added a minor fix in the spacing handling for the markdown CDATA in remarks, and adjusted the existing unit tests accordingly.