### PR TITLE
Add ability to find symbol in mono corelib and in other platform locations

### DIFF
--- a/Libraries/Docs/DocsCommentsContainer.cs
+++ b/Libraries/Docs/DocsCommentsContainer.cs
@@ -117,8 +117,9 @@ namespace Libraries.Docs
 
         private IEnumerable<FileInfo> EnumerateFiles()
         {
-            var includedAssembliesAndNamespaces = Config.IncludedAssemblies.Concat(Config.IncludedNamespaces);
-            var excludedAssembliesAndNamespaces = Config.ExcludedAssemblies.Concat(Config.ExcludedNamespaces);
+            // Union avoids duplication
+            var includedAssembliesAndNamespaces = Config.IncludedAssemblies.Union(Config.IncludedNamespaces);
+            var excludedAssembliesAndNamespaces = Config.ExcludedAssemblies.Union(Config.ExcludedNamespaces);
 
             foreach (DirectoryInfo rootDir in Config.DirsDocsXml)
             {
@@ -248,7 +249,7 @@ namespace Libraries.Docs
                     }
                 }
 
-                string message = $"Type {docsType.DocId} added with {totalMembersAdded} member(s) included.";
+                string message = $"Type '{docsType.DocId}' added with {totalMembersAdded} member(s) included: {fileInfo.FullName}";
                 if (addedAsInterface)
                 {
                     Log.Magenta("[Interface] - " + message);

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -134,6 +134,21 @@ namespace Libraries
             Magenta(true, format, args);
         }
 
+        public static void DarkYellow(bool endline, string format, params object[]? args)
+        {
+            Print(endline, ConsoleColor.DarkYellow, format, args);
+        }
+
+        public static void DarkYellow(string format)
+        {
+            DarkYellow(format, null);
+        }
+
+        public static void DarkYellow(string format, params object[]? args)
+        {
+            DarkYellow(true, format, args);
+        }
+
         public static void Assert(bool condition, string format)
         {
             Assert(true, condition, format, null);

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -114,6 +114,11 @@ namespace Libraries
             Cyan(true, format, args);
         }
 
+        public static void Cyan(bool endline, string format, params object[]? args)
+        {
+            Print(endline, ConsoleColor.Cyan, format, args);
+        }
+
         public static void Magenta(bool endline, string format, params object[]? args)
         {
             Print(endline, ConsoleColor.Magenta, format, args);
@@ -127,11 +132,6 @@ namespace Libraries
         public static void Magenta(string format, params object[]? args)
         {
             Magenta(true, format, args);
-        }
-
-        public static void Cyan(bool endline, string format, params object[]? args)
-        {
-            Print(endline, ConsoleColor.Cyan, format, args);
         }
 
         public static void Assert(bool condition, string format)

--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -90,6 +90,9 @@ namespace Libraries.RoslynTripleSlash
     {
         private static readonly string[] ReservedKeywords = new[] { "abstract", "async", "await", "false", "null", "sealed", "static", "true", "virtual" };
 
+        private static readonly string[] UnconvertableMarkdownStrings =
+            new[] { "](http", "[!code-cpp", "[!code-csharp", "[!code-vb", "[!INCLUDE", "[!NOTE]", "```cs", "```cpp", "```vb", "```visualbasic" };
+
         private static readonly Dictionary<string, string> PrimitiveTypes = new()
         {
             { "System.Boolean", "bool" },
@@ -453,10 +456,7 @@ namespace Libraries.RoslynTripleSlash
         {
             if (!api.Remarks.IsDocsEmpty())
             {
-                string text = GetRemarksWithXmlElements(api);
-                XmlTextSyntax contents = GetTextAsCommentedTokens(text, leadingWhitespace);
-                XmlElementSyntax xmlRemarks = SyntaxFactory.XmlRemarksElement(contents);
-                return GetXmlTrivia(xmlRemarks, leadingWhitespace);
+                return GetFormattedRemarks(api, leadingWhitespace);
             }
 
             return new();
@@ -631,7 +631,7 @@ namespace Libraries.RoslynTripleSlash
             return relateds;
         }
 
-        private static XmlTextSyntax GetTextAsCommentedTokens(string text, SyntaxTriviaList leadingWhitespace)
+        private static XmlTextSyntax GetTextAsCommentedTokens(string text, SyntaxTriviaList leadingWhitespace, bool wrapWithNewLines = false)
         {
             text = ReplacePrimitiveTypes(text);
 
@@ -642,9 +642,14 @@ namespace Libraries.RoslynTripleSlash
             SyntaxTrivia leadingTrivia = SyntaxFactory.SyntaxTrivia(SyntaxKind.DocumentationCommentExteriorTrivia, string.Empty);
             SyntaxTriviaList leading = SyntaxTriviaList.Create(leadingTrivia);
             
+            string[] lines = text.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
             var tokens = new List<SyntaxToken>();
 
-            string[] lines = text.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (wrapWithNewLines)
+            {
+                tokens.Add(whitespaceToken);
+            }
 
             for (int lineNumber = 0; lineNumber < lines.Length; lineNumber++)
             {
@@ -657,6 +662,11 @@ namespace Libraries.RoslynTripleSlash
                 {
                     tokens.Add(whitespaceToken);
                 }
+            }
+
+            if (wrapWithNewLines)
+            {
+                tokens.Add(whitespaceToken);
             }
 
             XmlTextSyntax xmlText = SyntaxFactory.XmlText(tokens.ToArray());
@@ -693,40 +703,95 @@ namespace Libraries.RoslynTripleSlash
             return GetXmlTrivia(element, leadingWhitespace);
         }
 
-        private static string GetRemarksWithXmlElements(IDocsAPI api)
+        private static bool ContainsUnconvertableMarkdown(string text)
         {
-            string remarks = api.Remarks;
-
-            if (!api.Remarks.IsDocsEmpty())
+            foreach (string markdown in UnconvertableMarkdownStrings)
             {
-                remarks = Regex.Replace(remarks, @"<!\[CDATA\[(\r?\n)*[\t ]*", "");
-                remarks = Regex.Replace(remarks, @"\]\]>", "");
-                remarks = Regex.Replace(remarks, @"##[ ]?Remarks(\r?\n)*[\t ]*", "");
-                remarks = Regex.Replace(remarks, @"(?<xref><xref\:(?<DocId>[a-zA-Z0-9_,\.\[\]\(\)`\{\}\@\+\*\&\^\#]+)(?<OverloadIndicator>%2A)?(?<extraVars>\?[a-zA-Z0-9_]+=[a-zA-Z0-9_]+)?>)", "<see cref=\"${DocId}\" />");
-
-                MatchCollection collection = Regex.Matches(api.Remarks, @"(?<backtickedParam>`(?<paramName>[a-zA-Z0-9_]+)`)");
-
-                foreach (Match match in collection)
+                if (text.Contains(markdown))
                 {
-                    string backtickedParam = match.Groups["backtickedParam"].Value;
-                    string paramName = match.Groups["paramName"].Value;
-                    if (ReservedKeywords.Any(x => x == paramName))
-                    {
-                        remarks = Regex.Replace(remarks, $"{backtickedParam}", $"<see langword=\"{paramName}\" />");
-                    }
-                    else if (api.Params.Any(x => x.Name == paramName))
-                    {
-                        remarks = Regex.Replace(remarks, $"{backtickedParam}", $"<paramref name=\"{paramName}\" />");
-                    }
-                    else if (api.TypeParams.Any(x => x.Name == paramName))
-                    {
-                        remarks = Regex.Replace(remarks, $"{backtickedParam}", $"<typeparamref name=\"{paramName}\" />");
-                    }
+                    return true;
                 }
-
-                remarks = ReplacePrimitiveTypes(remarks);
             }
-            return remarks;
+
+            return false;
+        }
+
+        /// <remarks><format type="text/markdown"><![CDATA[
+        /// ## Remarks
+        /// ]]></format></remarks>
+        private static SyntaxTriviaList GetFormattedRemarks(IDocsAPI api, SyntaxTriviaList leadingWhitespace)
+        {
+            string text = RemoveUnnecessaryMarkdown(api.Remarks);
+
+            XmlNodeSyntax contents;
+            if (ContainsUnconvertableMarkdown(text))
+            {
+                contents = GetTextAsFormatCData(text, leadingWhitespace);
+            }
+            else
+            {
+                text = GetRemarksWithXmlElements(text, api.Params, api.TypeParams);
+                contents = GetTextAsCommentedTokens(text, leadingWhitespace);
+            }
+
+            XmlElementSyntax xmlRemarks = SyntaxFactory.XmlRemarksElement(contents);
+            return GetXmlTrivia(xmlRemarks, leadingWhitespace);
+        }
+
+        private static XmlNodeSyntax GetTextAsFormatCData(string text, SyntaxTriviaList leadingWhitespace)
+        {
+            XmlTextSyntax remarks = GetTextAsCommentedTokens(text, leadingWhitespace, wrapWithNewLines: true);
+
+            XmlNameSyntax formatName = SyntaxFactory.XmlName("format");
+            XmlAttributeSyntax formatAttribute = SyntaxFactory.XmlTextAttribute("type", "text/markdown");
+            var formatAttributes = new SyntaxList<XmlAttributeSyntax>(formatAttribute);
+
+            var formatStart = SyntaxFactory.XmlElementStartTag(formatName, formatAttributes);
+            var formatEnd = SyntaxFactory.XmlElementEndTag(formatName);
+
+            XmlCDataSectionSyntax cdata = SyntaxFactory.XmlCDataSection(remarks.TextTokens);
+            var cdataList = new SyntaxList<XmlNodeSyntax>(cdata);
+
+            XmlElementSyntax contents = SyntaxFactory.XmlElement(formatStart, cdataList, formatEnd);
+
+            return contents;
+        }
+
+        private static string RemoveUnnecessaryMarkdown(string text)
+        {
+            text = Regex.Replace(text, @"<!\[CDATA\[(\r?\n)*[\t ]*", "");
+            text = Regex.Replace(text, @"\]\]>", "");
+            text = Regex.Replace(text, @"##[ ]?Remarks(\r?\n)*[\t ]*", "");
+            return text;
+        }
+
+        private static string GetRemarksWithXmlElements(string text, List<DocsParam> docsParams, List<DocsTypeParam> docsTypeParams)
+        {
+            text = Regex.Replace(text, @"(?<xref><xref\:(?<DocId>[a-zA-Z0-9_,\.\[\]\(\)`\{\}\@\+\*\&\^\#]+)(?<OverloadIndicator>%2A)?(?<extraVars>\?[a-zA-Z0-9_]+=[a-zA-Z0-9_]+)?>)", "<see cref=\"${DocId}\" />");
+
+            MatchCollection collection = Regex.Matches(text, @"(?<backtickedParam>`(?<paramName>[a-zA-Z0-9_]+)`)");
+
+            foreach (Match match in collection)
+            {
+                string backtickedParam = match.Groups["backtickedParam"].Value;
+                string paramName = match.Groups["paramName"].Value;
+                if (ReservedKeywords.Any(x => x == paramName))
+                {
+                    text = Regex.Replace(text, $"{backtickedParam}", $"<see langword=\"{paramName}\" />");
+                }
+                else if (docsParams.Any(x => x.Name == paramName))
+                {
+                    text = Regex.Replace(text, $"{backtickedParam}", $"<paramref name=\"{paramName}\" />");
+                }
+                else if (docsTypeParams.Any(x => x.Name == paramName))
+                {
+                    text = Regex.Replace(text, $"{backtickedParam}", $"<typeparamref name=\"{paramName}\" />");
+                }
+            }
+
+            text = ReplacePrimitiveTypes(text);
+
+            return text;
         }
 
         private static string RemoveDocIdPrefixes(string text)

--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -91,7 +91,7 @@ namespace Libraries.RoslynTripleSlash
         private static readonly string[] ReservedKeywords = new[] { "abstract", "async", "await", "false", "null", "sealed", "static", "true", "virtual" };
 
         private static readonly string[] UnconvertableMarkdownStrings =
-            new[] { "](http", "[!code-cpp", "[!code-csharp", "[!code-vb", "[!INCLUDE", "[!NOTE]", "```cs", "```cpp", "```vb", "```visualbasic" };
+            new[] { "](http", "](/", "[!code-cpp", "[!code-csharp", "[!code-vb", "[!INCLUDE", "[!NOTE]", "[!IMPORTANT]", "```cs", "```cpp", "```vb", "```visualbasic" };
 
         private static readonly Dictionary<string, string> PrimitiveTypes = new()
         {

--- a/Tests/PortToTripleSlash/TestData/Basic/MyDelegate.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyDelegate.xml
@@ -8,7 +8,18 @@
     <param name="e">This is the e parameter.</param>
     <typeparam name="T">This is the MyDelegate typeparam T.</typeparam>
     <summary>This is the MyDelegate summary.</summary>
-    <remarks>To be added.</remarks>
+    <remarks>
+      <format type="text/markdown">
+  <![CDATA[
+
+## Remarks
+
+These are the <xref:MyNamespace.MyType.MyDelegate`1> remarks. There is a code example, which should prevent converting markdown to xml:
+
+[!code-csharp[MyExample](~/samples/snippets/example.cs)]
+
+      ]]></format>
+    </remarks>
     <altmember cref="T:System.Delegate" />
     <seealso cref="T:System.Delegate" />
     <related type="Article" href="https://github.com/dotnet/runtime">The .NET Runtime repo.</related>

--- a/Tests/PortToTripleSlash/TestData/Basic/MyEnum.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyEnum.xml
@@ -1,0 +1,40 @@
+﻿<Type Name="MyEnum" FullName="MyNamespace.MyEnum">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyEnum" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>This is the MyEnum enum summary.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyEnumValue0">
+      <MemberSignature Language="DocId" Value="F:MyNamespace.MyEnum.MyEnumValue0" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <MemberValue>0</MemberValue>
+      <Docs>
+        <summary>This is the MyEnumValue0 member summary. There is no public modifier.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="MyEnumValue1">
+      <MemberSignature Language="DocId" Value="F:MyNamespace.MyEnum.MyEnumValue1" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <MemberValue>1</MemberValue>
+      <Docs>
+        <summary>This is the MyEnumValue1 member summary. There is no public modifier.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/PortToTripleSlash/TestData/Basic/MyEnum.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyEnum.xml
@@ -5,7 +5,15 @@
   </AssemblyInfo>
   <Docs>
     <summary>This is the MyEnum enum summary.</summary>
-    <remarks>To be added.</remarks>
+    <remarks>
+      <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+These are the <xref:MyNamespace.MyEnum> enum remarks. They contain an [!INCLUDE[MyInclude](~/includes/MyInclude.md)] which should prevent converting markdown to xml.
+
+      ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName="MyEnumValue0">

--- a/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
@@ -14,6 +14,9 @@ These are the MyType class remarks.
 
 Multiple lines.
 
+> [!NOTE]
+> This note should prevent converting markdown to xml.
+
       ]]></format>
     </remarks>
   </Docs>
@@ -95,11 +98,7 @@ Multiple lines.
 
 These are the MyIntMethod remarks.
 
-Multiple lines.
-
-Mentions the `param1`, the <xref:System.ArgumentNullException> and the `param2`.
-
-There are also a `true` and a `null`.
+There is a hyperlink, which should prevent the conversion from markdown to xml: [MyHyperlink](http://github.com/dotnet/runtime).
 
           ]]></format>
         </remarks>
@@ -173,6 +172,10 @@ This is a reference to the typeparam `T`.
 
 This is a reference to the parameter `param1`.
 
+Mentions the `param1` and an <xref:System.ArgumentNullException>.
+
+There are also a `true` and a `null`.
+
           ]]></format>
         </remarks>
       </Docs>
@@ -199,7 +202,7 @@ This is a reference to the parameter `param1`.
         <param name="value2">The second type to add.</param>
         <summary>Adds two MyType instances.</summary>
         <returns>The added types.</returns>
-        <remarks>To be added.</remarks>
+        <remarks>These are the <see cref="M:MyNamespace.MyType.op_Addition(MyNamespace.MyType,MyNamespace.MyType)" /> remarks. They are in plain xml and should be transferred unmodified.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -2,6 +2,16 @@
 
 namespace MyNamespace
 {
+    /// <summary>This is the MyEnum enum summary.</summary>
+    public enum MyEnum
+    {
+        /// <summary>This is the MyEnumValue0 member summary. There is no public modifier.</summary>
+        MyEnumValue0 = 0,
+
+        /// <summary>This is the MyEnumValue1 member summary. There is no public modifier.</summary>
+        MyEnumValue1 = 1
+    }
+
     /// <summary>This is the MyType class summary.</summary>
     /// <remarks>These are the MyType class remarks.
     /// Multiple lines.</remarks>

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -3,6 +3,9 @@
 namespace MyNamespace
 {
     /// <summary>This is the MyEnum enum summary.</summary>
+    /// <remarks><format type="text/markdown"><![CDATA[
+    /// These are the <xref:MyNamespace.MyEnum> enum remarks. They contain an [!INCLUDE[MyInclude](~/includes/MyInclude.md)] which should prevent converting markdown to xml.
+    /// ]]></format></remarks>
     public enum MyEnum
     {
         /// <summary>This is the MyEnumValue0 member summary. There is no public modifier.</summary>
@@ -13,8 +16,12 @@ namespace MyNamespace
     }
 
     /// <summary>This is the MyType class summary.</summary>
-    /// <remarks>These are the MyType class remarks.
-    /// Multiple lines.</remarks>
+    /// <remarks><format type="text/markdown"><![CDATA[
+    /// These are the MyType class remarks.
+    /// Multiple lines.
+    /// > [!NOTE]
+    /// > This note should prevent converting markdown to xml.
+    /// ]]></format></remarks>
     public class MyType
     {
         /// <summary>This is the MyType constructor summary.</summary>
@@ -57,10 +64,10 @@ namespace MyNamespace
         /// <param name="param1">This is the MyIntMethod param1 summary.</param>
         /// <param name="param2">This is the MyIntMethod param2 summary.</param>
         /// <returns>This is the MyIntMethod return value. It mentions the <see cref="System.ArgumentNullException" />.</returns>
-        /// <remarks>These are the MyIntMethod remarks.
-        /// Multiple lines.
-        /// Mentions the <paramref name="param1" />, the <see cref="System.ArgumentNullException" /> and the <paramref name="param2" />.
-        /// There are also a <see langword="true" /> and a <see langword="null" />.</remarks>
+        /// <remarks><format type="text/markdown"><![CDATA[
+        /// These are the MyIntMethod remarks.
+        /// There is a hyperlink, which should prevent the conversion from markdown to xml: [MyHyperlink](http://github.com/dotnet/runtime).
+        /// ]]></format></remarks>
         /// <exception cref="System.ArgumentNullException">This is the ArgumentNullException thrown by MyIntMethod. It mentions the <paramref name="param1" />.</exception>
         /// <exception cref="System.IndexOutOfRangeException">This is the IndexOutOfRangeException thrown by MyIntMethod.</exception>
         public int MyIntMethod(int param1, int param2)
@@ -100,7 +107,9 @@ namespace MyNamespace
         /// <param name="param1">This is the MyTypeParamMethod parameter param1.</param>
         /// <typeparam name="T">This is the MyTypeParamMethod typeparam T.</typeparam>
         /// <remarks>This is a reference to the typeparam <typeparamref name="T" />.
-        /// This is a reference to the parameter <paramref name="param1" />.</remarks>
+        /// This is a reference to the parameter <paramref name="param1" />.
+        /// Mentions the <paramref name="param1" /> and an <see cref="System.ArgumentNullException" />.
+        /// There are also a <see langword="true" /> and a <see langword="null" />.</remarks>
         public void MyTypeParamMethod<T>(int param1)
         {
         }
@@ -109,6 +118,10 @@ namespace MyNamespace
         /// <param name="sender">This is the sender parameter.</param>
         /// <param name="e">This is the e parameter.</param>
         /// <typeparam name="T">This is the MyDelegate typeparam T.</typeparam>
+        /// <remarks><format type="text/markdown"><![CDATA[
+        /// These are the <xref:MyNamespace.MyType.MyDelegate`1> remarks. There is a code example, which should prevent converting markdown to xml:
+        /// [!code-csharp[MyExample](~/samples/snippets/example.cs)]
+        /// ]]></format></remarks>
         /// <seealso cref="System.Delegate"/>
         /// <altmember cref="System.Delegate"/>
         /// <related type="Article" href="https://github.com/dotnet/runtime">The .NET Runtime repo.</related>
@@ -121,6 +134,7 @@ namespace MyNamespace
         /// <param name="value1">The first type to add.</param>
         /// <param name="value2">The second type to add.</param>
         /// <returns>The added types.</returns>
+        /// <remarks>These are the <see cref="MyNamespace.MyType.op_Addition(MyNamespace.MyType,MyNamespace.MyType)" /> remarks. They are in plain xml and should be transferred unmodified.</remarks>
         public static MyType operator +(MyType value1, MyType value2)
         {
             return value1;

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceOriginal.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceOriginal.cs
@@ -2,6 +2,13 @@
 
 namespace MyNamespace
 {
+    public enum MyEnum
+    {
+        MyEnumValue0 = 0,
+
+        MyEnumValue1 = 1
+    }
+
     public class MyType
     {
         /// <summary>


### PR DESCRIPTION
If a symbol is not found in the main project, we look for it in the referenced projects. If one of the projects happens to be System.Private.CoreLib, and we don't find the symbol in the Libraries version, then we have to try to find it in the Mono version.

If a symbol has multiple implementations for different platforms, ensure to port comments to those files too.

cc @safern