### PR TITLE
Convert links and examples in remarks as xml

### DIFF
--- a/Libraries/Extensions.cs
+++ b/Libraries/Extensions.cs
@@ -31,6 +31,19 @@ namespace Libraries
             return newString;
         }
 
+        public static bool ContainsStrings(this string text, string[] strings)
+        {
+            foreach (string str in strings)
+            {
+                if (text.Contains(str))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         // Some API DocIDs with types contain "{" and "}" to enclose the typeparam, which causes
         // an exception to be thrown when trying to embed the string in a formatted string.
         public static string Escaped(this string str) => str.Replace("{", "{{").Replace("}", "}}");

--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -794,7 +794,7 @@ namespace Libraries.RoslynTripleSlash
                     {
                         updatedRemarks += WrapCodeIncludes(splitted, ref n);
                     }
-                    // When example is found, everything is considered part of examples
+                    // When an example is found, everything after the header is considered part of that section
                     else if (line.Contains("## Example"))
                     {
                         n++;
@@ -814,11 +814,10 @@ namespace Libraries.RoslynTripleSlash
                     }
                     else
                     {
-                        updatedRemarks += Environment.NewLine + line;
+                        updatedRemarks += ReplaceMarkdownWithXmlElements(Environment.NewLine + line, api.Params, api.TypeParams);
                     }
                 }
 
-                updatedRemarks = ReplaceMarkdownWithXmlElements(updatedRemarks, api.Params, api.TypeParams);
                 contents = GetTextAsCommentedTokens(updatedRemarks, leadingWhitespace);
             }
 

--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -729,9 +729,9 @@ namespace Libraries.RoslynTripleSlash
 
         private static string WrapInRemarks(string acum)
         {
-            string wrapped = "\r\n<format type=\"text/markdown\"><![CDATA[\r\n";
+            string wrapped = Environment.NewLine + "<format type=\"text/markdown\"><![CDATA[" + Environment.NewLine;
             wrapped += acum;
-            wrapped += "\r\n]]></format>\r\n";
+            wrapped += Environment.NewLine + "]]></format>" + Environment.NewLine;
             return wrapped;
         }
 
@@ -766,7 +766,7 @@ namespace Libraries.RoslynTripleSlash
             }
             else
             {
-                string[] splitted = remarks.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+                string[] splitted = remarks.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
                 string updatedRemarks = string.Empty;
                 for (int n = 0; n < splitted.Length; n++)
                 {

--- a/Tests/PortToTripleSlash/TestData/Basic/MyDelegate.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyDelegate.xml
@@ -18,9 +18,15 @@ These are the <xref:MyNamespace.MyType.MyDelegate`1> remarks. There is a code ex
 
 ## Examples
 
+Here is some text in the examples section. There is an <xref:MyNamespace.MyType.MyDelegate`1> that should be converted to xml.
+
+The snippet links below should be inserted in markdown.
+
 [!code-csharp[MyExample#1](~/samples/snippets/example.cs)]
 [!code-vb[MyExample#2](~/samples/snippets/example.vb)]
 [!code-cpp[MyExample#3](~/samples/snippets/example.cpp)]
+
+This text should be outside the cdata in xml: <xref:MyNamespace.MyType>.
 
       ]]></format>
     </remarks>

--- a/Tests/PortToTripleSlash/TestData/Basic/MyDelegate.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyDelegate.xml
@@ -14,9 +14,13 @@
 
 ## Remarks
 
-These are the <xref:MyNamespace.MyType.MyDelegate`1> remarks. There is a code example, which should prevent converting markdown to xml:
+These are the <xref:MyNamespace.MyType.MyDelegate`1> remarks. There is a code example, which should be moved to its own examples section:
 
-[!code-csharp[MyExample](~/samples/snippets/example.cs)]
+## Examples
+
+[!code-csharp[MyExample#1](~/samples/snippets/example.cs)]
+[!code-vb[MyExample#2](~/samples/snippets/example.vb)]
+[!code-cpp[MyExample#3](~/samples/snippets/example.cpp)]
 
       ]]></format>
     </remarks>

--- a/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
@@ -16,7 +16,7 @@ These are the <xref:MyNamespace.MyType> class remarks.
 Multiple lines.
 
 > [!NOTE]
-> This note should prevent converting markdown to xml.
+> This note should prevent converting markdown to xml. It has a <xref:MyNamespace.MyEnum>.
 
 This text is not a note. It has a <xref:MyNamespace.MyType> that should be xml and outside the cdata.
 

--- a/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
@@ -76,6 +76,19 @@ There is a primitive type <xref:System.Int32> here.
 
 Multiple lines.
 
+## Example
+
+This example section has a header in singular.
+
+```cs
+MyType t = new MyType();
+```
+```vb
+Dim t = New MyType()
+```
+```cpp
+MyType t = MyType();
+```
           ]]></format>
         </remarks>
       </Docs>
@@ -98,7 +111,7 @@ Multiple lines.
 
 These are the MyIntMethod remarks.
 
-There is a hyperlink, which should prevent the conversion from markdown to xml: [MyHyperlink](http://github.com/dotnet/runtime).
+There is a hyperlink, which should still allow conversion from markdown to xml: [MyHyperlink](http://github.com/dotnet/runtime).
 
           ]]></format>
         </remarks>

--- a/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
@@ -6,16 +6,19 @@
   <Docs>
     <summary>This is the MyType class summary.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[
+      <format type="text/markdown">
+  <![CDATA[
 
 ## Remarks
 
-These are the MyType class remarks.
+These are the <xref:MyNamespace.MyType> class remarks.
 
 Multiple lines.
 
 > [!NOTE]
 > This note should prevent converting markdown to xml.
+
+This text is not a note. It has a <xref:MyNamespace.MyType> that should be xml and outside the cdata.
 
       ]]></format>
     </remarks>
@@ -110,6 +113,10 @@ MyType t = MyType();
 ## Remarks
 
 These are the MyIntMethod remarks.
+
+Here is a random snippet, NOT preceded by the examples header.
+
+[!code-cpp[MyExample](~/samples/snippets/example.cpp)]
 
 There is a hyperlink, which should still allow conversion from markdown to xml: [MyHyperlink](http://github.com/dotnet/runtime).
 

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -20,7 +20,7 @@ namespace MyNamespace
     /// Multiple lines.
     /// <format type="text/markdown"><![CDATA[
     /// > [!NOTE]
-    /// > This note should prevent converting markdown to xml.
+    /// > This note should prevent converting markdown to xml. It has a <xref:MyNamespace.MyEnum>.
     /// ]]></format>
     /// This text is not a note. It has a <see cref="MyNamespace.MyType" /> that should be xml and outside the cdata.</remarks>
     public class MyType

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -16,12 +16,13 @@ namespace MyNamespace
     }
 
     /// <summary>This is the MyType class summary.</summary>
-    /// <remarks><format type="text/markdown"><![CDATA[
-    /// These are the MyType class remarks.
+    /// <remarks>These are the <see cref="MyNamespace.MyType" /> class remarks.
     /// Multiple lines.
+    /// <format type="text/markdown"><![CDATA[
     /// > [!NOTE]
     /// > This note should prevent converting markdown to xml.
-    /// ]]></format></remarks>
+    /// ]]></format>
+    /// This text is not a note. It has a <see cref="MyNamespace.MyType" /> that should be xml and outside the cdata.</remarks>
     public class MyType
     {
         /// <summary>This is the MyType constructor summary.</summary>
@@ -75,6 +76,10 @@ namespace MyNamespace
         /// <param name="param2">This is the MyIntMethod param2 summary.</param>
         /// <returns>This is the MyIntMethod return value. It mentions the <see cref="System.ArgumentNullException" />.</returns>
         /// <remarks>These are the MyIntMethod remarks.
+        /// Here is a random snippet, NOT preceded by the examples header.
+        /// <format type="text/markdown"><![CDATA[
+        /// [!code-cpp[MyExample](~/samples/snippets/example.cpp)]
+        /// ]]></format>
         /// There is a hyperlink, which should still allow conversion from markdown to xml: <a href="http://github.com/dotnet/runtime">MyHyperlink</a>.</remarks>
         /// <exception cref="System.ArgumentNullException">This is the ArgumentNullException thrown by MyIntMethod. It mentions the <paramref name="param1" />.</exception>
         /// <exception cref="System.IndexOutOfRangeException">This is the IndexOutOfRangeException thrown by MyIntMethod.</exception>
@@ -127,11 +132,14 @@ namespace MyNamespace
         /// <param name="e">This is the e parameter.</param>
         /// <typeparam name="T">This is the MyDelegate typeparam T.</typeparam>
         /// <remarks>These are the <see cref="MyNamespace.MyType.MyDelegate`1" /> remarks. There is a code example, which should be moved to its own examples section:</remarks>
-        /// <example><format type="text/markdown"><![CDATA[
+        /// <example>Here is some text in the examples section. There is an <see cref="MyNamespace.MyType.MyDelegate`1" /> that should be converted to xml.
+        /// The snippet links below should be inserted in markdown.
+        /// <format type="text/markdown"><![CDATA[
         /// [!code-csharp[MyExample#1](~/samples/snippets/example.cs)]
         /// [!code-vb[MyExample#2](~/samples/snippets/example.vb)]
         /// [!code-cpp[MyExample#3](~/samples/snippets/example.cpp)]
-        /// ]]></format></example>
+        /// ]]></format>
+        /// This text should be outside the cdata in xml: <see cref="MyNamespace.MyType" />.</example>
         /// <seealso cref="System.Delegate"/>
         /// <altmember cref="System.Delegate"/>
         /// <related type="Article" href="https://github.com/dotnet/runtime">The .NET Runtime repo.</related>

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -58,16 +58,24 @@ namespace MyNamespace
         /// <remarks>These are the MyField remarks.
         /// There is a primitive type <see cref="int" /> here.
         /// Multiple lines.</remarks>
+        /// <example>This example section has a header in singular.
+        /// <code class="lang-cs">
+        /// MyType t = new MyType();
+        /// </code>
+        /// <code class="lang-vb">
+        /// Dim t = New MyType()
+        /// </code>
+        /// <code class="lang-cpp">
+        /// MyType t = MyType();
+        /// </code></example>
         public int MyField = 1;
 
         /// <summary>This is the MyIntMethod summary.</summary>
         /// <param name="param1">This is the MyIntMethod param1 summary.</param>
         /// <param name="param2">This is the MyIntMethod param2 summary.</param>
         /// <returns>This is the MyIntMethod return value. It mentions the <see cref="System.ArgumentNullException" />.</returns>
-        /// <remarks><format type="text/markdown"><![CDATA[
-        /// These are the MyIntMethod remarks.
-        /// There is a hyperlink, which should prevent the conversion from markdown to xml: [MyHyperlink](http://github.com/dotnet/runtime).
-        /// ]]></format></remarks>
+        /// <remarks>These are the MyIntMethod remarks.
+        /// There is a hyperlink, which should still allow conversion from markdown to xml: <a href="http://github.com/dotnet/runtime">MyHyperlink</a>.</remarks>
         /// <exception cref="System.ArgumentNullException">This is the ArgumentNullException thrown by MyIntMethod. It mentions the <paramref name="param1" />.</exception>
         /// <exception cref="System.IndexOutOfRangeException">This is the IndexOutOfRangeException thrown by MyIntMethod.</exception>
         public int MyIntMethod(int param1, int param2)
@@ -118,10 +126,12 @@ namespace MyNamespace
         /// <param name="sender">This is the sender parameter.</param>
         /// <param name="e">This is the e parameter.</param>
         /// <typeparam name="T">This is the MyDelegate typeparam T.</typeparam>
-        /// <remarks><format type="text/markdown"><![CDATA[
-        /// These are the <xref:MyNamespace.MyType.MyDelegate`1> remarks. There is a code example, which should prevent converting markdown to xml:
-        /// [!code-csharp[MyExample](~/samples/snippets/example.cs)]
-        /// ]]></format></remarks>
+        /// <remarks>These are the <see cref="MyNamespace.MyType.MyDelegate`1" /> remarks. There is a code example, which should be moved to its own examples section:</remarks>
+        /// <example><format type="text/markdown"><![CDATA[
+        /// [!code-csharp[MyExample#1](~/samples/snippets/example.cs)]
+        /// [!code-vb[MyExample#2](~/samples/snippets/example.vb)]
+        /// [!code-cpp[MyExample#3](~/samples/snippets/example.cpp)]
+        /// ]]></format></example>
         /// <seealso cref="System.Delegate"/>
         /// <altmember cref="System.Delegate"/>
         /// <related type="Article" href="https://github.com/dotnet/runtime">The .NET Runtime repo.</related>


### PR DESCRIPTION
Increase the cases that allow converting markdown to xml, so we have fewer remarks backported as markdown.