### PR TITLE
Fix install-as-tool script

### DIFF
--- a/install-as-tool.ps1
+++ b/install-as-tool.ps1
@@ -4,8 +4,7 @@ $ErrorActionPreference = "Stop"
 Push-Location $(Split-Path $MyInvocation.MyCommand.Path)
 
 $ARTIFACTS_DIR = "artifacts"
-$PROJECT_NAME = "Program"
 $BUILD_CONFIGURATION = "Release"
 
-dotnet pack -c $BUILD_CONFIGURATION -o $ARTIFACTS_DIR $PROJECT_NAME
+dotnet pack -c $BUILD_CONFIGURATION -o $ARTIFACTS_DIR "Program"
 dotnet tool update --global --add-source $ARTIFACTS_DIR "DocsPortingTool"

--- a/install-as-tool.ps1
+++ b/install-as-tool.ps1
@@ -8,4 +8,4 @@ $PROJECT_NAME = "Program"
 $BUILD_CONFIGURATION = "Release"
 
 dotnet pack -c $BUILD_CONFIGURATION -o $ARTIFACTS_DIR $PROJECT_NAME
-dotnet tool update --global --add-source $ARTIFACTS_DIR $PROJECT_NAME
+dotnet tool update --global --add-source $ARTIFACTS_DIR "DocsPortingTool"


### PR DESCRIPTION
@eiriktsarpalis thanks for catching the issue. Program should not be used as a publishing project name or it would collide with others.
Can you help me verify that this fix works for you?