### PR TITLE
Preserve double slash comments in public APIs, and some markdown conversions

### DIFF
--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -108,6 +108,9 @@ namespace Libraries.RoslynTripleSlash
         private static readonly string RegexMarkdownXrefOverloadPattern = @"(?<xref><xref\:(?<DocId>[" + ValidRegexChars + @"]+)%2[aA](?<extraVars>\?[" + ValidRegexChars + @"]+=[" + ValidRegexChars + @"]+)?>)";
         private static readonly string RegexXmlSeeCrefOverloadReplacement = "<see cref=\"O:${DocId}\" />";
 
+        private static readonly string RegexMarkdownBoldPattern = @"\*\*(?<content>[A-Za-z0-9\-\._~:\/#\[\]@!\$&'\(\)\+,;%` ]+)\*\*";
+        private static readonly string RegexXmlBoldReplacement = @"<b>${content}</b>";
+
         private static readonly string RegexMarkdownLinkPattern = @"\[(?<linkValue>.+)\]\((?<linkURL>(http|www)[" + ValidRegexChars + ValidExtraChars + @"]+)\)";
         private static readonly string RegexHtmlLinkReplacement = "<a href=\"${linkURL}\">${linkValue}</a>";
 
@@ -879,6 +882,9 @@ namespace Libraries.RoslynTripleSlash
 
             // hyperlinks
             text = Regex.Replace(text, RegexMarkdownLinkPattern, RegexHtmlLinkReplacement);
+
+            // bold
+            text = Regex.Replace(text, RegexMarkdownBoldPattern, RegexXmlBoldReplacement);
 
             // code snippet
             text = Regex.Replace(text, RegexMarkdownCodeStartPattern, RegexXmlCodeStartReplacement);

--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -96,8 +96,7 @@ namespace Libraries.RoslynTripleSlash
 
         private static readonly string[] MarkdownExamples = new[] { "## Examples", "## Example" };
 
-        private static readonly string MarkdownNote = "[!NOTE]";
-        private static readonly string MarkdownImportant = "[!IMPORTANT]";
+        private static readonly string[] MarkdownHeaders = new[] { "[!NOTE]", "[!IMPORTANT]", "[!TIP]" };
 
         private static readonly string ValidRegexChars = @"A-Za-z0-9\-\._~:\/#\[\]@!\$&'\(\)\*\+,;%`";
         private static readonly string ValidExtraChars = @"\?=";
@@ -793,7 +792,7 @@ namespace Libraries.RoslynTripleSlash
                 {
                     string acum;
                     string line = splitted[n];
-                    if (line.Contains(MarkdownImportant) || line.Contains(MarkdownNote))
+                    if (line.ContainsStrings(MarkdownHeaders))
                     {
                         acum = line;
                         n++;

--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -880,6 +880,12 @@ namespace Libraries.RoslynTripleSlash
             // see crefs
             text = Regex.Replace(text, RegexMarkdownXrefPattern, RegexXmlSeeCrefReplacement);
 
+            // commonly used url entities
+            text = Regex.Replace(text, @"%23", "#");
+            text = Regex.Replace(text, @"%28", "(");
+            text = Regex.Replace(text, @"%29", ")");
+            text = Regex.Replace(text, @"%2C", ",");
+
             // hyperlinks
             text = Regex.Replace(text, RegexMarkdownLinkPattern, RegexHtmlLinkReplacement);
 

--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -445,25 +445,43 @@ namespace Libraries.RoslynTripleSlash
         // Finds the last set of whitespace characters that are to the left of the public|protected keyword of the node.
         private static SyntaxTriviaList GetLeadingWhitespace(SyntaxNode node)
         {
+            SyntaxTriviaList triviaList = GetLeadingTrivia(node);
+
+            if (triviaList.Any() &&
+                triviaList.LastOrDefault(t => t.IsKind(SyntaxKind.WhitespaceTrivia)) is SyntaxTrivia last)
+            {
+                return new(last);
+            }
+
+            return new();
+        }
+
+        private static SyntaxTriviaList GetLeadingDoubleSlashComments(SyntaxNode node)
+        {
+            SyntaxTriviaList triviaList = GetLeadingTrivia(node);
+
+            if (triviaList.Any() &&
+                triviaList.FirstOrDefault(t => t.IsKind(SyntaxKind.SingleLineCommentTrivia)) is SyntaxTrivia last)
+            {
+                return new(last);
+            }
+
+            return new();
+        }
+
+        private static SyntaxTriviaList GetLeadingTrivia(SyntaxNode node)
+        {
             if (node is MemberDeclarationSyntax memberDeclaration)
             {
-                SyntaxTriviaList triviaList;
-
                 if ((memberDeclaration.Modifiers.FirstOrDefault(x => x.IsKind(SyntaxKind.PublicKeyword) || x.IsKind(SyntaxKind.ProtectedKeyword)) is SyntaxToken modifier) &&
                         !modifier.IsKind(SyntaxKind.None))
                 {
-                    triviaList = modifier.LeadingTrivia;
-                }
-                else
-                {
-                    triviaList = node.GetLeadingTrivia();
+                    return modifier.LeadingTrivia;
                 }
 
-                if (triviaList.LastOrDefault(t => t.IsKind(SyntaxKind.WhitespaceTrivia)) is SyntaxTrivia last)
-                {
-                    return new(last);
-                }
+                return node.GetLeadingTrivia();
             }
+
             return new();
         }
 

--- a/Tests/PortToTripleSlash/TestData/Basic/MyEnum.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyEnum.xml
@@ -6,11 +6,14 @@
   <Docs>
     <summary>This is the MyEnum enum summary.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[
+      <format type="text/markdown">
+  <![CDATA[
 
 ## Remarks
 
 These are the <xref:MyNamespace.MyEnum> enum remarks. They contain an [!INCLUDE[MyInclude](~/includes/MyInclude.md)] which should prevent converting markdown to xml.
+
+URL entities: %23%28%2C%29 must remain unconverted.
 
       ]]></format>
     </remarks>

--- a/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
@@ -18,7 +18,7 @@ Multiple lines.
 > [!NOTE]
 > This note should prevent converting markdown to xml. It has a <xref:MyNamespace.MyEnum>.
 
-This text is not a note. It has a <xref:MyNamespace.MyType> that should be xml and outside the cdata.
+This text is not a note. It has a <xref:MyNamespace.MyType> that should be xml and outside **the cdata**.
 
       ]]></format>
     </remarks>

--- a/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
+++ b/Tests/PortToTripleSlash/TestData/Basic/MyType.xml
@@ -13,6 +13,8 @@
 
 These are the <xref:MyNamespace.MyType> class remarks.
 
+URL entities: %23%28%29%2C.
+
 Multiple lines.
 
 > [!NOTE]

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -30,7 +30,8 @@ namespace MyNamespace
     public class MyType
     {
         /// <summary>This is the MyType constructor summary.</summary>
-        // Original MyType constructor double slash comments with information for maintainers, must stay.
+        // Original MyType constructor double slash comments on top of triple slash, with information for maintainers, must stay but after triple slash.
+        // Original MyType constructor double slash comments on bottom of triple slash, with information for maintainers, must stay.
         public MyType()
         {
         } /* Trailing comments should remain untouched */
@@ -53,6 +54,8 @@ namespace MyNamespace
         /// <value>This is the MyProperty value.</value>
         /// <remarks>These are the MyProperty remarks.
         /// Multiple lines and a reference to the field <see cref="MyNamespace.MyType.MyField" /> and the xref uses displayProperty, which should be ignored when porting.</remarks>
+        // Original MyProperty property double slash comments with information for maintainers, must stay.
+        // This particular example has two rows of double slash comments and both should stay.
         public int MyProperty
         {
             get { return _myProperty; /* Internal comments should remain untouched. */ }

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -22,7 +22,7 @@ namespace MyNamespace
     /// > [!NOTE]
     /// > This note should prevent converting markdown to xml. It has a <xref:MyNamespace.MyEnum>.
     /// ]]></format>
-    /// This text is not a note. It has a <see cref="MyNamespace.MyType" /> that should be xml and outside the cdata.</remarks>
+    /// This text is not a note. It has a <see cref="MyNamespace.MyType" /> that should be xml and outside <b>the cdata</b>.</remarks>
     public class MyType
     {
         /// <summary>This is the MyType constructor summary.</summary>

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -7,6 +7,7 @@ namespace MyNamespace
     /// These are the <xref:MyNamespace.MyEnum> enum remarks. They contain an [!INCLUDE[MyInclude](~/includes/MyInclude.md)] which should prevent converting markdown to xml.
     /// URL entities: %23%28%2C%29 must remain unconverted.
     /// ]]></format></remarks>
+    // Original MyEnum enum comments with information for maintainers, must stay.
     public enum MyEnum
     {
         /// <summary>This is the MyEnumValue0 member summary. There is no public modifier.</summary>
@@ -25,14 +26,16 @@ namespace MyNamespace
     /// > This note should prevent converting markdown to xml. It has a <xref:MyNamespace.MyEnum>.
     /// ]]></format>
     /// This text is not a note. It has a <see cref="MyNamespace.MyType" /> that should be xml and outside <b>the cdata</b>.</remarks>
+    // Original MyType class comments with information for maintainers, must stay.
     public class MyType
     {
         /// <summary>This is the MyType constructor summary.</summary>
+        // Original MyType constructor double slash comments with information for maintainers, must stay.
         public MyType()
         {
         } /* Trailing comments should remain untouched */
 
-        // Original double slash comments. They should not be replaced (internal).
+        // Original double slash comments, must stay (internal method).
         internal MyType(int myProperty)
         {
             _myProperty = myProperty;
@@ -145,6 +148,7 @@ namespace MyNamespace
         /// <seealso cref="System.Delegate"/>
         /// <altmember cref="System.Delegate"/>
         /// <related type="Article" href="https://github.com/dotnet/runtime">The .NET Runtime repo.</related>
+        // Original MyDelegate delegate comments with information for maintainers, must stay.
         public delegate void MyDelegate<T>(object sender, T e);
 
         /// <summary>This is the MyEvent summary.</summary>
@@ -155,6 +159,7 @@ namespace MyNamespace
         /// <param name="value2">The second type to add.</param>
         /// <returns>The added types.</returns>
         /// <remarks>These are the <see cref="MyNamespace.MyType.op_Addition(MyNamespace.MyType,MyNamespace.MyType)" /> remarks. They are in plain xml and should be transferred unmodified.</remarks>
+        // Original operator + method comments with information for maintainers, must stay.
         public static MyType operator +(MyType value1, MyType value2)
         {
             return value1;

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -5,6 +5,7 @@ namespace MyNamespace
     /// <summary>This is the MyEnum enum summary.</summary>
     /// <remarks><format type="text/markdown"><![CDATA[
     /// These are the <xref:MyNamespace.MyEnum> enum remarks. They contain an [!INCLUDE[MyInclude](~/includes/MyInclude.md)] which should prevent converting markdown to xml.
+    /// URL entities: %23%28%2C%29 must remain unconverted.
     /// ]]></format></remarks>
     public enum MyEnum
     {
@@ -17,6 +18,7 @@ namespace MyNamespace
 
     /// <summary>This is the MyType class summary.</summary>
     /// <remarks>These are the <see cref="MyNamespace.MyType" /> class remarks.
+    /// URL entities: #(),.
     /// Multiple lines.
     /// <format type="text/markdown"><![CDATA[
     /// > [!NOTE]

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceOriginal.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceOriginal.cs
@@ -13,10 +13,11 @@ namespace MyNamespace
     // Original MyType class comments with information for maintainers, must stay.
     public class MyType
     {
+        // Original MyType constructor double slash comments on top of triple slash, with information for maintainers, must stay but after triple slash.
         /// <summary>
         /// Original triple slash comments. They should be replaced.
         /// </summary>
-        // Original MyType constructor double slash comments with information for maintainers, must stay.
+        // Original MyType constructor double slash comments on bottom of triple slash, with information for maintainers, must stay.
         public MyType()
         {
         } /* Trailing comments should remain untouched */
@@ -38,7 +39,8 @@ namespace MyNamespace
         /// <summary>
         /// Original triple slash comments. They should be replaced.
         /// </summary>
-        // Original double slash comments. They should be replaced.
+        // Original MyProperty property double slash comments with information for maintainers, must stay.
+        // This particular example has two rows of double slash comments and both should stay.
         public int MyProperty
         {
             get { return _myProperty; /* Internal comments should remain untouched. */ }

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceOriginal.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceOriginal.cs
@@ -2,6 +2,7 @@
 
 namespace MyNamespace
 {
+    // Original MyEnum enum comments with information for maintainers, must stay.
     public enum MyEnum
     {
         MyEnumValue0 = 0,
@@ -9,16 +10,18 @@ namespace MyNamespace
         MyEnumValue1 = 1
     }
 
+    // Original MyType class comments with information for maintainers, must stay.
     public class MyType
     {
         /// <summary>
         /// Original triple slash comments. They should be replaced.
         /// </summary>
+        // Original MyType constructor double slash comments with information for maintainers, must stay.
         public MyType()
         {
         } /* Trailing comments should remain untouched */
 
-        // Original double slash comments. They should not be replaced (internal).
+        // Original double slash comments, must stay (internal method).
         internal MyType(int myProperty)
         {
             _myProperty = myProperty;
@@ -70,10 +73,12 @@ namespace MyNamespace
         {
         }
 
+        // Original MyDelegate delegate comments with information for maintainers, must stay.
         public delegate void MyDelegate<T>(object sender, T e);
 
         public event MyDelegate MyEvent;
 
+        // Original operator + method comments with information for maintainers, must stay.
         public static MyType operator +(MyType value1, MyType value2)
         {
             return value1;


### PR DESCRIPTION
If a public API has double slash comments, there's no need to replace them with triple slash because they may contain information that is critical to code maintainers. So I'm putting them at the bottom after adding the triple slash comments.

Detecting some more markdown elements and converting them to their xml equivalent.

Detecting `[!TIP]` and keeping it as markdown.

Added these cases to unit test.