### PR TITLE
Fix bug preventing loading types from System.Private.CoreLib

### DIFF
--- a/Libraries/ToTripleSlashPorter.cs
+++ b/Libraries/ToTripleSlashPorter.cs
@@ -180,8 +180,9 @@ namespace Libraries
                 string projectNamespace = Path.GetFileNameWithoutExtension(projectPath);
 
                 // Skip looking in projects whose namespace that were explicitly excluded or not explicitly included
-                if (Config.ExcludedNamespaces.Any(x => x.StartsWith(projectNamespace)) ||
-                    !Config.IncludedNamespaces.Any(x => x.StartsWith(projectNamespace)))
+                if (projectNamespace.ToUpperInvariant() != "SYSTEM.PRIVATE.CORELIB" &&
+                    (Config.ExcludedNamespaces.Any(x => x.StartsWith(projectNamespace)) ||
+                    !Config.IncludedNamespaces.Any(x => x.StartsWith(projectNamespace))))
                 {
                     Log.Info($"Skipping project '{projectPath}'...");
                     continue;


### PR DESCRIPTION
The tool receives a list of namespaces from the command line arguments. The user can filter the types they want to backport by specifying their namespaces.

The tool looks at the project name and determines if it was included or excluded by the user, but I forgot to skip System.Private.CoreLib from this check because it's a special project that should always be included.

I fixed it by detecting when this project is being analyzed and skip the namespace check when S.P.CoreLib is the current project.

@tannergooding