### PR TITLE
Count condition was wrong

### DIFF
--- a/Libraries/ToTripleSlashPorter.cs
+++ b/Libraries/ToTripleSlashPorter.cs
@@ -413,7 +413,7 @@ namespace Libraries
                     }
                 }
 
-                if (allMsgs.Count > 1)
+                if (allMsgs.Count > 0)
                 {
                     Log.Error($"Diagnostic messages found in {stepName}:");
                     foreach (string msg in allMsgs)


### PR DESCRIPTION
This typo was preventing diagnostic errors from showing up.

@tannergooding @eiriktsarpalis after I merge this, can you please update the tool, rerun it and then send me the diagnostic errors you're getting?

This is the error I am getting in my machine:
```
Diagnostic messages found in workspace.OpenProjectAsync - MyAssembly.csproj:
    Failure - Msbuild failed when processing the file 'ProjectMyAssembly.csproj' with message:
    The SDK resolver type "WorkloadSdkResolver" failed to load.
    Could not load file or assembly 'System.Runtime, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
    The system cannot find the file specified.
```

Knowing which error you get will help @safern and I investigate the root cause.