### PR TITLE
Update MSBuild locator to not resolve SDKs newer than the runtime

### DIFF
--- a/Program/DocsPortingTool.csproj
+++ b/Program/DocsPortingTool.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="16.8.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
The reason why this was failing is because the old MSBuild locator was resolving the newest SDK regardless of the runtime that the tool was running on. This: https://github.com/microsoft/MSBuildLocator/issues/92 fixed that issue and only returns SDKs that are same or earlier than the runtime the tool is running on. 

cc: @carlossanlop 