### PR TITLE
Upgrade to net6.0 to prevent dependency issues after upgrading MSBuild.Locator

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/DocsPortingTool.sln
+++ b/DocsPortingTool.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
 		BackportInstructions.md = BackportInstructions.md
+		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
 		install-as-tool.ps1 = install-as-tool.ps1
 		README.md = README.md
 	EndProjectSection

--- a/Libraries/Libraries.csproj
+++ b/Libraries/Libraries.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Company>Microsoft</Company>
     <Authors>carlossanlop</Authors>
     <Nullable>enable</Nullable>

--- a/Program/DocsPortingTool.csproj
+++ b/Program/DocsPortingTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <StartupObject>DocsPortingTool.DocsPortingTool</StartupObject>
     <Company>Microsoft</Company>
     <Authors>carlossanlop</Authors>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Company>Microsoft</Company>
     <Authors>carlossanlop</Authors>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Related to https://github.com/carlossanlop/DocsPortingTool/pull/40
cc @safern @ericstj