### PR TITLE
Bug fixes: Mono symbols can't be found. Tool is slow.

### DIFF
--- a/Libraries/ToTripleSlashPorter.cs
+++ b/Libraries/ToTripleSlashPorter.cs
@@ -361,34 +361,6 @@ namespace Libraries
         // If any diagnostic error messages are captured after each step (workspace load, project load, compilation load), an exception is thrown.
         private ProjectInformation GetProjectInfo(string projectPath, bool isMono)
         {
-            //MSBuildWorkspace workspace;
-            //try
-            //{
-            //    // If project has implementations in mono,
-            //    // we need to port docs to mono-specific locations too
-            //    if (isMono)
-            //    {
-            //        Dictionary<string, string> workspaceProperties = new()
-            //        {
-            //            { "RuntimeFlavor", "Mono" }
-            //        };
-            //        workspace = MSBuildWorkspace.Create(workspaceProperties);
-            //    }
-            //    else
-            //    {
-            //        workspace = MSBuildWorkspace.Create();
-            //    }
-            //    Log.Info("Created a workspace for '{0}'{1}.", projectPath, isMono ? " with RuntimeFlavor=Mono enabled" : "");
-            //}
-            //catch
-            //{
-            //    Log.Error("The MSBuild directory was not found in PATH. Use '-MSBuild <directory>' to specify it.");
-            //    throw;
-            //}
-
-            // Prevents exception when trying to load C# projects that are not csproj
-
-
             MSBuildWorkspace workspace = GetOrAddWorkspace(
                 isMono ? WorkspacesMono : Workspaces,
                 isMono ? WorkspaceProperties : null,

--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@
 This tool finds and ports triple slash comments found in .NET repos but **do not yet exist** in the dotnet-api-docs repo.
 If an API is already documented in dotnet-api-docs, it will be ignored and skipped.
 
+Instructions to backport Docs to triple slash can be found [here](~/BackportingInstructions.md).
+
 ## Requirements
 
 - [.NET 6.0 SDK](https://github.com/dotnet/installer#installers-and-binaries)
 
 ## Instructions
-
-Instructions to backport Docs to triple slash can be found [here](~/BackportingInstructions.md).
-
 
 1. Build your source code repo. For example: dotnet/runtime, or dotnet/wpf, or dotnet/winforms, etc.
 2. Clone the docs repo (dotnet/dotnet-api-docs). No need to build it.


### PR DESCRIPTION
Fixed bug preventing the tool from looking for Mono source code.

Improved speed by caching the workspaces, projects and compilations that are opened each time. No need to reopen them from scratch when exploring references.

Minor fix in readme.
