### PR TITLE
Change order of triple slash items

### DIFF
--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -243,7 +243,7 @@ namespace Libraries.RoslynTripleSlash
             SyntaxTriviaList altmembers = GetAltMembers(member.AltMembers, leadingWhitespace);
             SyntaxTriviaList relateds = GetRelateds(member.Relateds, leadingWhitespace);
 
-            return GetNodeWithTrivia(leadingWhitespace, node, summary, value, remarks, exceptions, seealsos, altmembers, relateds);
+            return GetNodeWithTrivia(leadingWhitespace, node, summary, value, exceptions, remarks, seealsos, altmembers, relateds);
         }
 
         public override SyntaxNode? VisitRecordDeclaration(RecordDeclarationSyntax node)
@@ -308,7 +308,7 @@ namespace Libraries.RoslynTripleSlash
             SyntaxTriviaList relateds = GetRelateds(type.Relateds, leadingWhitespace);
 
 
-            return GetNodeWithTrivia(leadingWhitespace, node, summary, parameters, typeParameters, remarks, seealsos, altmembers, relateds);
+            return GetNodeWithTrivia(leadingWhitespace, node, summary, typeParameters, parameters, remarks, seealsos, altmembers, relateds);
         }
 
         private SyntaxNode? VisitBaseMethodDeclaration(BaseMethodDeclarationSyntax node)
@@ -332,7 +332,7 @@ namespace Libraries.RoslynTripleSlash
             SyntaxTriviaList altmembers = GetAltMembers(member.AltMembers, leadingWhitespace);
             SyntaxTriviaList relateds = GetRelateds(member.Relateds, leadingWhitespace);
 
-            return GetNodeWithTrivia(leadingWhitespace, node, summary, parameters, typeParameters, returns, remarks, exceptions, seealsos, altmembers, relateds);
+            return GetNodeWithTrivia(leadingWhitespace, node, summary, typeParameters, parameters, returns, exceptions, remarks, seealsos, altmembers, relateds);
         }
 
         private SyntaxNode? VisitMemberDeclaration(MemberDeclarationSyntax node)
@@ -351,7 +351,7 @@ namespace Libraries.RoslynTripleSlash
             SyntaxTriviaList altmembers = GetAltMembers(member.AltMembers, leadingWhitespace);
             SyntaxTriviaList relateds = GetRelateds(member.Relateds, leadingWhitespace);
 
-            return GetNodeWithTrivia(leadingWhitespace, node, summary, remarks, exceptions, seealsos, altmembers, relateds);
+            return GetNodeWithTrivia(leadingWhitespace, node, summary, exceptions, remarks, seealsos, altmembers, relateds);
         }
 
         private SyntaxNode? VisitVariableDeclaration(BaseFieldDeclarationSyntax node)

--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -237,8 +237,8 @@ namespace Libraries.RoslynTripleSlash
 
             SyntaxTriviaList summary = GetSummary(member, leadingWhitespace);
             SyntaxTriviaList value = GetValue(member, leadingWhitespace);
-            SyntaxTriviaList remarks = GetRemarks(member, leadingWhitespace);
             SyntaxTriviaList exceptions = GetExceptions(member.Exceptions, leadingWhitespace);
+            SyntaxTriviaList remarks = GetRemarks(member, leadingWhitespace);
             SyntaxTriviaList seealsos = GetSeeAlsos(member.SeeAlsoCrefs, leadingWhitespace);
             SyntaxTriviaList altmembers = GetAltMembers(member.AltMembers, leadingWhitespace);
             SyntaxTriviaList relateds = GetRelateds(member.Relateds, leadingWhitespace);
@@ -300,9 +300,9 @@ namespace Libraries.RoslynTripleSlash
             }
 
             SyntaxTriviaList summary = GetSummary(type, leadingWhitespace);
-            SyntaxTriviaList remarks = GetRemarks(type, leadingWhitespace);
-            SyntaxTriviaList parameters = GetParameters(type, leadingWhitespace);
             SyntaxTriviaList typeParameters = GetTypeParameters(type, leadingWhitespace);
+            SyntaxTriviaList parameters = GetParameters(type, leadingWhitespace);
+            SyntaxTriviaList remarks = GetRemarks(type, leadingWhitespace);
             SyntaxTriviaList seealsos = GetSeeAlsos(type.SeeAlsoCrefs, leadingWhitespace);
             SyntaxTriviaList altmembers = GetAltMembers(type.AltMembers, leadingWhitespace);
             SyntaxTriviaList relateds = GetRelateds(type.Relateds, leadingWhitespace);
@@ -323,11 +323,11 @@ namespace Libraries.RoslynTripleSlash
             SyntaxTriviaList leadingWhitespace = GetLeadingWhitespace(node);
 
             SyntaxTriviaList summary = GetSummary(member, leadingWhitespace);
-            SyntaxTriviaList parameters = GetParameters(member, leadingWhitespace);
             SyntaxTriviaList typeParameters = GetTypeParameters(member, leadingWhitespace);
+            SyntaxTriviaList parameters = GetParameters(member, leadingWhitespace);
             SyntaxTriviaList returns = GetReturns(member, leadingWhitespace);
-            SyntaxTriviaList remarks = GetRemarks(member, leadingWhitespace);
             SyntaxTriviaList exceptions = GetExceptions(member.Exceptions, leadingWhitespace);
+            SyntaxTriviaList remarks = GetRemarks(member, leadingWhitespace);
             SyntaxTriviaList seealsos = GetSeeAlsos(member.SeeAlsoCrefs, leadingWhitespace);
             SyntaxTriviaList altmembers = GetAltMembers(member.AltMembers, leadingWhitespace);
             SyntaxTriviaList relateds = GetRelateds(member.Relateds, leadingWhitespace);
@@ -345,8 +345,8 @@ namespace Libraries.RoslynTripleSlash
             SyntaxTriviaList leadingWhitespace = GetLeadingWhitespace(node);
 
             SyntaxTriviaList summary = GetSummary(member, leadingWhitespace);
-            SyntaxTriviaList remarks = GetRemarks(member, leadingWhitespace);
             SyntaxTriviaList exceptions = GetExceptions(member.Exceptions, leadingWhitespace);
+            SyntaxTriviaList remarks = GetRemarks(member, leadingWhitespace);
             SyntaxTriviaList seealsos = GetSeeAlsos(member.SeeAlsoCrefs, leadingWhitespace);
             SyntaxTriviaList altmembers = GetAltMembers(member.AltMembers, leadingWhitespace);
             SyntaxTriviaList relateds = GetRelateds(member.Relateds, leadingWhitespace);

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -84,14 +84,14 @@ namespace MyNamespace
         /// <param name="param1">This is the MyIntMethod param1 summary.</param>
         /// <param name="param2">This is the MyIntMethod param2 summary.</param>
         /// <returns>This is the MyIntMethod return value. It mentions the <see cref="System.ArgumentNullException" />.</returns>
+        /// <exception cref="System.ArgumentNullException">This is the ArgumentNullException thrown by MyIntMethod. It mentions the <paramref name="param1" />.</exception>
+        /// <exception cref="System.IndexOutOfRangeException">This is the IndexOutOfRangeException thrown by MyIntMethod.</exception>
         /// <remarks>These are the MyIntMethod remarks.
         /// Here is a random snippet, NOT preceded by the examples header.
         /// <format type="text/markdown"><![CDATA[
         /// [!code-cpp[MyExample](~/samples/snippets/example.cpp)]
         /// ]]></format>
         /// There is a hyperlink, which should still allow conversion from markdown to xml: <a href="http://github.com/dotnet/runtime">MyHyperlink</a>.</remarks>
-        /// <exception cref="System.ArgumentNullException">This is the ArgumentNullException thrown by MyIntMethod. It mentions the <paramref name="param1" />.</exception>
-        /// <exception cref="System.IndexOutOfRangeException">This is the IndexOutOfRangeException thrown by MyIntMethod.</exception>
         public int MyIntMethod(int param1, int param2)
         {
             // Internal comments should remain untouched.
@@ -99,16 +99,16 @@ namespace MyNamespace
         }
 
         /// <summary>This is the MyVoidMethod summary.</summary>
-        /// <remarks>These are the MyVoidMethod remarks.
-        /// Multiple lines.
-        /// Mentions the <see cref="System.ArgumentNullException" />.
-        /// Also mentions an overloaded method DocID: <see cref="MyNamespace.MyType.MyIntMethod" />.
-        /// And also mentions an overloaded method DocID with displayProperty which should be ignored when porting: <see cref="MyNamespace.MyType.MyIntMethod" />.</remarks>
         /// <exception cref="System.ArgumentNullException">This is the ArgumentNullException thrown by MyVoidMethod. It mentions the <paramref name="param1" />.</exception>
         /// <exception cref="System.IndexOutOfRangeException">This is the IndexOutOfRangeException thrown by MyVoidMethod.
         /// -or-
         /// This is the second case.
         /// Empty newlines should be respected.</exception>
+        /// <remarks>These are the MyVoidMethod remarks.
+        /// Multiple lines.
+        /// Mentions the <see cref="System.ArgumentNullException" />.
+        /// Also mentions an overloaded method DocID: <see cref="MyNamespace.MyType.MyIntMethod" />.
+        /// And also mentions an overloaded method DocID with displayProperty which should be ignored when porting: <see cref="MyNamespace.MyType.MyIntMethod" />.</remarks>
         public void MyVoidMethod()
         {
         }
@@ -126,8 +126,8 @@ namespace MyNamespace
         }
 
         /// <summary>This is the MyTypeParamMethod summary.</summary>
-        /// <param name="param1">This is the MyTypeParamMethod parameter param1.</param>
         /// <typeparam name="T">This is the MyTypeParamMethod typeparam T.</typeparam>
+        /// <param name="param1">This is the MyTypeParamMethod parameter param1.</param>
         /// <remarks>This is a reference to the typeparam <typeparamref name="T" />.
         /// This is a reference to the parameter <paramref name="param1" />.
         /// Mentions the <paramref name="param1" /> and an <see cref="System.ArgumentNullException" />.
@@ -137,9 +137,9 @@ namespace MyNamespace
         }
 
         /// <summary>This is the MyDelegate summary.</summary>
+        /// <typeparam name="T">This is the MyDelegate typeparam T.</typeparam>
         /// <param name="sender">This is the sender parameter.</param>
         /// <param name="e">This is the e parameter.</param>
-        /// <typeparam name="T">This is the MyDelegate typeparam T.</typeparam>
         /// <remarks>These are the <see cref="MyNamespace.MyType.MyDelegate{T}" /> remarks. There is a code example, which should be moved to its own examples section:</remarks>
         /// <example>Here is some text in the examples section. There is an <see cref="MyNamespace.MyType.MyDelegate{T}" /> that should be converted to xml.
         /// The snippet links below should be inserted in markdown.


### PR DESCRIPTION
Fixes #43

Add exceptions before remarks.
Add typeparams before params.

cc @eiriktsarpalis