### PR TITLE
Use the correct type name for generic and nested types

### DIFF
--- a/Libraries/Docs/DocsType.cs
+++ b/Libraries/Docs/DocsType.cs
@@ -10,6 +10,7 @@ namespace Libraries.Docs
     /// </summary>
     internal class DocsType : DocsAPI
     {
+        private string? _typeName;
         private string? _name;
         private string? _fullName;
         private string? _namespace;
@@ -30,6 +31,29 @@ namespace Libraries.Docs
         public XDocument XDoc { get; set; }
 
         public override bool Changed { get; set; }
+
+        public string TypeName
+        {
+            get
+            {
+                if (_typeName == null)
+                {
+                    // DocId uses ` notation for generic types, but it uses . for nested types
+                    // Name uses + for nested types, but it uses &lt;T&gt; for generic types
+                    // We need ` notation for generic types and + notation for nested types
+                    // Only filename gives us that format, but we have to prepend the namespace
+                    if (DocId.Contains('`') || Name.Contains('+'))
+                    {
+                        _typeName = Namespace + "." + System.IO.Path.GetFileNameWithoutExtension(FilePath);
+                    }
+                    else
+                    {
+                        _typeName = FullName;
+                    }
+                }
+                return _typeName;
+            }
+        }
 
         public string Name
         {

--- a/Libraries/ToTripleSlashPorter.cs
+++ b/Libraries/ToTripleSlashPorter.cs
@@ -145,7 +145,7 @@ namespace Libraries
             {
                 // If the symbol is not found in the current compilation, nothing to do - It means the Docs
                 // for APIs from an unrelated namespace were loaded for this compilation's assembly
-                if (!TryGetNamedSymbol(mainProjectInfo.Compilation, docsType.FullName, out INamedTypeSymbol? symbol))
+                if (!TryGetNamedSymbol(mainProjectInfo.Compilation, docsType.TypeName, out INamedTypeSymbol? symbol))
                 {
                     Log.Info($"Type symbol '{docsType.FullName}' not found in compilation for '{Config.CsProj.FullName}'.");
                     continue;
@@ -221,7 +221,7 @@ namespace Libraries
                     }
                 }
 
-                if (TryFindSymbolInReferencedProject(projectPath, docsType.FullName, isMono: false, out ProjectInformation? projectInfo, out INamedTypeSymbol? symbol))
+                if (TryFindSymbolInReferencedProject(projectPath, docsType.TypeName, isMono: false, out ProjectInformation? projectInfo, out INamedTypeSymbol? symbol))
                 {
                     Log.Cyan($"Symbol '{docsType.FullName}' found in referenced project '{projectPath}'.");
 
@@ -234,7 +234,7 @@ namespace Libraries
                     // If the symbol was found in corelib, try to also find it in mono
                     if (projectNamespaceToUpper == SystemPrivateCoreLib &&
                         projectPath.Contains(_pathSrcCoreclr) &&
-                        TryFindSymbolInReferencedProject(monoProjectPath, docsType.FullName, isMono: true, out ProjectInformation? monoProjectInfo, out INamedTypeSymbol? monoSymbol))
+                        TryFindSymbolInReferencedProject(monoProjectPath, docsType.TypeName, isMono: true, out ProjectInformation? monoProjectInfo, out INamedTypeSymbol? monoSymbol))
                     {
                         Log.Info($"Symbol '{monoSymbol.Name}' was also found in Mono locations of project '{monoProjectInfo.Project.FilePath}'.");
                         AddSymbolLocationsToResolvedLocations(monoProjectInfo, monoSymbol, docsType);

--- a/Tests/PortToTripleSlash/PortToTripleSlashTestData.cs
+++ b/Tests/PortToTripleSlash/PortToTripleSlashTestData.cs
@@ -5,8 +5,11 @@ namespace Libraries.Tests
 {
     internal class PortToTripleSlashTestData : TestData
     {
-        private string TestDataRootDirPath => @"../../../PortToTripleSlash/TestData";
+        private const string SourceOriginal = "SourceOriginal.cs";
+        private const string SourceExpected = "SourceExpected.cs";
         private const string ProjectDirName = "Project";
+        private string TestDataRootDirPath => @"../../../PortToTripleSlash/TestData";
+
         private DirectoryInfo ProjectDir { get; set; }
         internal string ProjectFilePath { get; set; }
 
@@ -14,11 +17,9 @@ namespace Libraries.Tests
             TestDirectory tempDir,
             string testDataDir,
             string assemblyName,
-            string namespaceName,
-            string typeName)
+            string namespaceName)
         {
             Assert.False(string.IsNullOrWhiteSpace(assemblyName));
-            Assert.False(string.IsNullOrWhiteSpace(typeName));
 
             namespaceName = string.IsNullOrEmpty(namespaceName) ? assemblyName : namespaceName;
 
@@ -36,12 +37,12 @@ namespace Libraries.Tests
                 File.Copy(origin, destination);
             }
 
-            string originCsOriginal = Path.Combine(testDataPath, $"SourceOriginal.cs");
-            ActualFilePath = Path.Combine(ProjectDir.FullName, $"{typeName}.cs");
+            string originCsOriginal = Path.Combine(testDataPath, SourceOriginal);
+            ActualFilePath = Path.Combine(ProjectDir.FullName, SourceOriginal);
             File.Copy(originCsOriginal, ActualFilePath);
 
-            string originCsExpected = Path.Combine(testDataPath, $"SourceExpected.cs");
-            ExpectedFilePath = Path.Combine(tempDir.FullPath, $"SourceExpected.cs");
+            string originCsExpected = Path.Combine(testDataPath, SourceExpected);
+            ExpectedFilePath = Path.Combine(tempDir.FullPath, SourceExpected);
             File.Copy(originCsExpected, ExpectedFilePath);
 
             string originCsproj = Path.Combine(testDataPath, $"{assemblyName}.csproj");

--- a/Tests/PortToTripleSlash/PortToTripleSlashTests.cs
+++ b/Tests/PortToTripleSlash/PortToTripleSlashTests.cs
@@ -22,17 +22,15 @@ namespace Libraries.Tests
             bool save = true,
             bool skipInterfaceImplementations = true,
             string assemblyName = TestData.TestAssembly,
-            string namespaceName = TestData.TestNamespace,
-            string typeName = TestData.TestType)
+            string namespaceName = TestData.TestNamespace)
         {
             using TestDirectory tempDir = new();
 
             PortToTripleSlashTestData testData = new(
                 tempDir,
                 testDataDir,
-                assemblyName: assemblyName,
-                namespaceName: namespaceName,
-                typeName: typeName);
+                assemblyName,
+                namespaceName);
 
             Configuration c = new()
             {

--- a/Tests/PortToTripleSlash/PortToTripleSlashTests.cs
+++ b/Tests/PortToTripleSlash/PortToTripleSlashTests.cs
@@ -17,6 +17,12 @@ namespace Libraries.Tests
             PortToTripleSlash("Basic");
         }
 
+        [Fact]
+        public void Port_Generics()
+        {
+            PortToTripleSlash("Generics");
+        }
+
         private static void PortToTripleSlash(
             string testDataDir,
             bool save = true,

--- a/Tests/PortToTripleSlash/TestData/Generics/MyAssembly.csproj
+++ b/Tests/PortToTripleSlash/TestData/Generics/MyAssembly.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <Description>This is MyNamespace description.</Description>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/Tests/PortToTripleSlash/TestData/Generics/MyGenericType`1+Enumerator.xml
+++ b/Tests/PortToTripleSlash/TestData/Generics/MyGenericType`1+Enumerator.xml
@@ -1,0 +1,9 @@
+﻿<Type Name="MyGenericType&lt;T&gt;+Enumerator" FullName="MyNamespace.MyGenericType&lt;T&gt;+Enumerator">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyGenericType`1.Enumerator" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>This is the MyGenericType{T}.Enumerator class summary.</summary>
+  </Docs>
+</Type>

--- a/Tests/PortToTripleSlash/TestData/Generics/MyGenericType`1.xml
+++ b/Tests/PortToTripleSlash/TestData/Generics/MyGenericType`1.xml
@@ -1,0 +1,9 @@
+﻿<Type Name="MyGenericType&lt;T&gt;" FullName="MyNamespace.MyGenericType&lt;T&gt;">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyGenericType`1" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>This is the MyGenericType{T} class summary.</summary>
+  </Docs>
+</Type>

--- a/Tests/PortToTripleSlash/TestData/Generics/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Generics/SourceExpected.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace MyNamespace
+{
+    /// <summary>This is the MyGenericType{T} class summary.</summary>
+    // Original MyGenericType<T> class comments with information for maintainers, must stay.
+    public class MyGenericType<T>
+    {
+        /// <summary>This is the MyGenericType{T}.Enumerator class summary.</summary>
+        // Original MyGenericType<T>.Enumerator class comments with information for maintainers, must stay.
+        public class Enumerator { }
+    }
+}

--- a/Tests/PortToTripleSlash/TestData/Generics/SourceOriginal.cs
+++ b/Tests/PortToTripleSlash/TestData/Generics/SourceOriginal.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace MyNamespace
+{
+    // Original MyGenericType<T> class comments with information for maintainers, must stay.
+    public class MyGenericType<T>
+    {
+        // Original MyGenericType<T>.Enumerator class comments with information for maintainers, must stay.
+        public class Enumerator { }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="PortToTripleSlash\TestData\Generics\SourceExpected.cs" />
+    <Compile Remove="PortToTripleSlash\TestData\Generics\SourceOriginal.cs" />
     <Compile Remove="PortToTripleSlash\TestData\Basic\SourceExpected.cs" />
     <Compile Remove="PortToTripleSlash\TestData\Basic\SourceOriginal.cs" />
   </ItemGroup>
@@ -32,6 +34,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="PortToTripleSlash\TestData\Generics\MyAssembly.csproj" />
+    <None Include="PortToTripleSlash\TestData\Generics\SourceExpected.cs" />
+    <None Include="PortToTripleSlash\TestData\Generics\SourceOriginal.cs" />
     <None Include="PortToTripleSlash\TestData\Basic\SourceExpected.cs" />
     <None Include="PortToTripleSlash\TestData\Basic\SourceOriginal.cs" />
     <None Include="PortToTripleSlash\TestData\Basic\MyAssembly.csproj" />


### PR DESCRIPTION
Generic and nested type names were not getting formatted correctly. This was preventing docs for those types from getting ported into triple slash comments.

This was discovered while attempting to port `System.Buffers` and `System.Memory` for dotnet/runtime#48967 and dotnet/runtime#48964. The first symptom was that `ArrayPool<T>` docs were not getting ported. The second symptom was that `ReadOnlySequence<T>.Enumerator` docs were not getting ported.

Based on this discovery, I suspect any libraries already ported that contain public generic or nested types would need to have the tool rerun.