### PR TITLE
fix mapping of generic xref's to cref's

### DIFF
--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -105,7 +105,7 @@ namespace Libraries.RoslynTripleSlash
         private static readonly string ValidRegexChars = @"[A-Za-z0-9\-\._~:\/#\[\]\{\}@!\$&'\(\)\*\+,;]|`\d+|%\w{2}";
         private static readonly string ValidExtraChars = @"\?=";
 
-        private static readonly string RegexDocIdPattern = @"(?<prefix>[A-Za-z]{1}:)?(?<docId>(" + ValidRegexChars + @")+)(?<overload>%2[aA])?(?<extraVars>\?(" + ValidRegexChars + @")+=(" + ValidRegexChars + @")+)?";
+        private static readonly string RegexDocIdPattern = @"(?<prefix>[A-Za-z]{1}:)?(?<docId>(" + ValidRegexChars + @")+)?(?<extraVars>\?(" + ValidRegexChars + @")+=(" + ValidRegexChars + @")+)?";
         private static readonly string RegexXmlCrefPattern = "cref=\"" + RegexDocIdPattern + "\"";
         private static readonly string RegexMarkdownXrefPattern = @"(?<xref><xref:" + RegexDocIdPattern + ">)";
 
@@ -969,12 +969,14 @@ namespace Libraries.RoslynTripleSlash
         private static string ReplaceDocId(Match m)
         {
             string docId = m.Groups["docId"].Value;
-            string overload = string.IsNullOrWhiteSpace(m.Groups["overload"].Value) ? "" : "O:";
             docId = ReplacePrimitives(docId);
             docId = System.Net.WebUtility.UrlDecode(docId);
 
             // Strip '*' character from the tail end of DocId names
-            docId = Regex.Replace(docId, @"\*$", "");
+            if (docId.EndsWith('*'))
+            {
+                docId = docId[..^1];
+            }
 
             // Map DocId generic parameters to Xml Doc generic parameters
             // need to support both single and double backtick syntax
@@ -1007,7 +1009,7 @@ namespace Libraries.RoslynTripleSlash
                 static string WrapInCurlyBrackets(string input) => $"{{{input}}}";
             }
 
-            return overload + docId;
+            return docId;
         }
 
         private static string CrefEvaluator(Match m)

--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -970,16 +970,18 @@ namespace Libraries.RoslynTripleSlash
         private static string ReplaceDocId(Match m)
         {
             string docId = m.Groups["docId"].Value;
+            string? prefix = m.Groups["prefix"].Value == "O:" ? "O:" : null;
             docId = ReplacePrimitives(docId);
             docId = System.Net.WebUtility.UrlDecode(docId);
 
             // Strip '*' character from the tail end of DocId names
             if (docId.EndsWith('*'))
             {
+                prefix = "O:";
                 docId = docId[..^1];
             }
 
-            return MapDocIdGenericsToCrefGenerics(docId);
+            return prefix + MapDocIdGenericsToCrefGenerics(docId);
         }
 
         private static string MapDocIdGenericsToCrefGenerics(string docId)

--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -646,6 +646,7 @@ namespace Libraries.RoslynTripleSlash
         private static SyntaxTriviaList GetAltMember(string cref, SyntaxTriviaList leadingWhitespace)
         {
             cref = RemoveCrefPrefix(cref);
+            cref = MapDocIdGenericsToCrefGenerics(cref);
             XmlAttributeSyntax attribute = SyntaxFactory.XmlTextAttribute("cref", cref);
             XmlEmptyElementSyntax emptyElement = SyntaxFactory.XmlEmptyElement(SyntaxFactory.XmlName(SyntaxFactory.Identifier("altmember")), new SyntaxList<XmlAttributeSyntax>(attribute));
             return GetXmlTrivia(emptyElement, leadingWhitespace);
@@ -978,11 +979,17 @@ namespace Libraries.RoslynTripleSlash
                 docId = docId[..^1];
             }
 
+            return MapDocIdGenericsToCrefGenerics(docId);
+        }
+
+        private static string MapDocIdGenericsToCrefGenerics(string docId)
+        {
             // Map DocId generic parameters to Xml Doc generic parameters
             // need to support both single and double backtick syntax
             const string GenericParameterPattern = @"`{1,2}([\d+])";
             int genericParameterArity = 0;
-            docId = Regex.Replace(docId, GenericParameterPattern, MapDocIdGenericParameterToXmlDocGenericParameter);
+            return Regex.Replace(docId, GenericParameterPattern, MapDocIdGenericParameterToXmlDocGenericParameter);
+
             string MapDocIdGenericParameterToXmlDocGenericParameter(Match match)
             {
                 int index = int.Parse(match.Groups[1].Value);
@@ -1008,8 +1015,6 @@ namespace Libraries.RoslynTripleSlash
 
                 static string WrapInCurlyBrackets(string input) => $"{{{input}}}";
             }
-
-            return docId;
         }
 
         private static string CrefEvaluator(Match m)

--- a/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -107,8 +107,8 @@ namespace MyNamespace
         /// <remarks>These are the MyVoidMethod remarks.
         /// Multiple lines.
         /// Mentions the <see cref="System.ArgumentNullException" />.
-        /// Also mentions an overloaded method DocID: <see cref="MyNamespace.MyType.MyIntMethod" />.
-        /// And also mentions an overloaded method DocID with displayProperty which should be ignored when porting: <see cref="MyNamespace.MyType.MyIntMethod" />.</remarks>
+        /// Also mentions an overloaded method DocID: <see cref="O:MyNamespace.MyType.MyIntMethod" />.
+        /// And also mentions an overloaded method DocID with displayProperty which should be ignored when porting: <see cref="O:MyNamespace.MyType.MyIntMethod" />.</remarks>
         public void MyVoidMethod()
         {
         }

--- a/Tests/PortToTripleSlash/TestData/Generics/MyGenericType.xml
+++ b/Tests/PortToTripleSlash/TestData/Generics/MyGenericType.xml
@@ -1,0 +1,29 @@
+﻿<Type Name="MyGenericType&lt;T&gt;" FullName="MyNamespace.MyGenericType">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyGenericType" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>This is the MyGenericType static class summary.</summary>
+  </Docs>
+  <Members>
+    <Member MemberName="Select&lt;TSource,TResult&gt;">
+      <MemberSignature Language="DocId" Value="M:MyNamespace.MyGenericType.Select``2(MyNamespace.MyGenericType{``0},System.Func{``0,``1})" />
+      <Docs>
+        <summary>Projects each element into a new form.</summary>
+        <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+        <typeparam name="TResult">The type of the value returned by <paramref name="selector" />.</typeparam>
+        <param name="source">A sequence of values to invoke a transform function on.</param>
+        <param name="selector">A transform function to apply to each element.</param>
+        <remarks>
+          <format type="text/markdown">
+            <![CDATA[
+## Remarks
+Here's a reference to <xref:MyNamespace.MyGenericType.Select%60%602%28MyNamespace.MyGenericType%7B%60%600%7D%2CSystem.Func%7B%60%600%2C%60%601%7D%29>.
+          ]]>
+          </format>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/PortToTripleSlash/TestData/Generics/MyGenericType.xml
+++ b/Tests/PortToTripleSlash/TestData/Generics/MyGenericType.xml
@@ -15,6 +15,7 @@
         <typeparam name="TResult">The type of the value returned by <paramref name="selector" />.</typeparam>
         <param name="source">A sequence of values to invoke a transform function on.</param>
         <param name="selector">A transform function to apply to each element.</param>
+        <altmember cref="System.Linq.Enumerable.Any``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})"/>
         <remarks>
           <format type="text/markdown">
             <![CDATA[

--- a/Tests/PortToTripleSlash/TestData/Generics/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Generics/SourceExpected.cs
@@ -11,4 +11,16 @@ namespace MyNamespace
         // Original MyGenericType<T>.Enumerator class comments with information for maintainers, must stay.
         public class Enumerator { }
     }
+
+    /// <summary>This is the MyGenericType static class summary.</summary>
+    public static class MyGenericType
+    {
+        /// <summary>Projects each element into a new form.</summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+        /// <typeparam name="TResult">The type of the value returned by <paramref name="selector" />.</typeparam>
+        /// <param name="source">A sequence of values to invoke a transform function on.</param>
+        /// <param name="selector">A transform function to apply to each element.</param>
+        /// <remarks>Here's a reference to <see cref="MyNamespace.MyGenericType.Select{T1,T2}(MyNamespace.MyGenericType{T1},System.Func{T1,T2})" />.</remarks>
+        public static MyGenericType<TResult> Select<TSource, TResult>(this MyGenericType<TSource> source, Func<TSource, TResult> selector) => null;
+    }
 }

--- a/Tests/PortToTripleSlash/TestData/Generics/SourceExpected.cs
+++ b/Tests/PortToTripleSlash/TestData/Generics/SourceExpected.cs
@@ -21,6 +21,7 @@ namespace MyNamespace
         /// <param name="source">A sequence of values to invoke a transform function on.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <remarks>Here's a reference to <see cref="MyNamespace.MyGenericType.Select{T1,T2}(MyNamespace.MyGenericType{T1},System.Func{T1,T2})" />.</remarks>
+        /// <altmember cref="System.Linq.Enumerable.Any{T}(System.Collections.Generic.IEnumerable{T},System.Func{T,System.Boolean})"/>
         public static MyGenericType<TResult> Select<TSource, TResult>(this MyGenericType<TSource> source, Func<TSource, TResult> selector) => null;
     }
 }

--- a/Tests/PortToTripleSlash/TestData/Generics/SourceOriginal.cs
+++ b/Tests/PortToTripleSlash/TestData/Generics/SourceOriginal.cs
@@ -8,4 +8,9 @@ namespace MyNamespace
         // Original MyGenericType<T>.Enumerator class comments with information for maintainers, must stay.
         public class Enumerator { }
     }
+
+    public static class MyGenericType
+    {
+        public static MyGenericType<TResult> Select<TSource, TResult>(this MyGenericType<TSource> source, Func<TSource, TResult> selector) => null;
+    }
 }


### PR DESCRIPTION
Related to #71. Addresses an issue in the xref mapping logic where generics with multiple parameters are not handled properly.

cc @carlossanlop @jeffhandley 