### PR TITLE
XML read/write

### DIFF
--- a/Libraries/Docs/DocsCommentsContainer.cs
+++ b/Libraries/Docs/DocsCommentsContainer.cs
@@ -86,7 +86,7 @@ namespace Libraries.Docs
                 }
                 catch (Exception e)
                 {
-                    Log.Error(e.Message);
+                    Log.Error("Failed to write to {0}. {1}", type.FilePath, e.Message);
                     Log.Line();
                     Log.Error(e.StackTrace ?? string.Empty);
                     if (e.InnerException != null)

--- a/Libraries/Docs/DocsCommentsContainer.cs
+++ b/Libraries/Docs/DocsCommentsContainer.cs
@@ -176,7 +176,10 @@ namespace Libraries.Docs
         {
             try
             {
-                xDoc = XDocument.Load(fileInfo.FullName);
+                // docs repo uses code page 1252
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                StreamReader sw = new(fileInfo.FullName, Encoding.GetEncoding(1252));
+                xDoc = XDocument.Load(sw);
             }
             catch(Exception ex)
             {

--- a/Libraries/Docs/DocsCommentsContainer.cs
+++ b/Libraries/Docs/DocsCommentsContainer.cs
@@ -174,11 +174,6 @@ namespace Libraries.Docs
 
         private void LoadFile(FileInfo fileInfo)
         {
-            if (!fileInfo.Exists)
-            {
-                throw new Exception($"Docs xml file does not exist: {fileInfo.FullName}");
-            }
-
             xDoc = XDocument.Load(fileInfo.FullName);
 
             if (IsXmlMalformed(xDoc, fileInfo.FullName))

--- a/Libraries/Docs/DocsCommentsContainer.cs
+++ b/Libraries/Docs/DocsCommentsContainer.cs
@@ -174,7 +174,15 @@ namespace Libraries.Docs
 
         private void LoadFile(FileInfo fileInfo)
         {
-            xDoc = XDocument.Load(fileInfo.FullName);
+            try
+            {
+                xDoc = XDocument.Load(fileInfo.FullName);
+            }
+            catch(Exception ex)
+            {
+                Log.Error(string.Format("Failed to load '{0}'. {1}", fileInfo.FullName, ex.ToString()));
+                return;
+            }
 
             if (IsXmlMalformed(xDoc, fileInfo.FullName))
             {

--- a/Libraries/Docs/DocsCommentsContainer.cs
+++ b/Libraries/Docs/DocsCommentsContainer.cs
@@ -183,7 +183,7 @@ namespace Libraries.Docs
             }
             catch(Exception ex)
             {
-                Log.Error($"Failed to load '{fileInfo.FullName}'. {ex.ToString()}");
+                Log.Error($"Failed to load '{fileInfo.FullName}'. {ex}");
                 return;
             }
 

--- a/Libraries/Docs/DocsCommentsContainer.cs
+++ b/Libraries/Docs/DocsCommentsContainer.cs
@@ -183,7 +183,7 @@ namespace Libraries.Docs
             }
             catch(Exception ex)
             {
-                Log.Error(string.Format("Failed to load '{0}'. {1}", fileInfo.FullName, ex.ToString()));
+                Log.Error($"Failed to load '{fileInfo.FullName}'. {ex.ToString()}");
                 return;
             }
 

--- a/Libraries/Docs/DocsCommentsContainer.cs
+++ b/Libraries/Docs/DocsCommentsContainer.cs
@@ -178,8 +178,8 @@ namespace Libraries.Docs
             {
                 // docs repo uses code page 1252
                 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-                StreamReader sw = new(fileInfo.FullName, Encoding.GetEncoding(1252));
-                xDoc = XDocument.Load(sw);
+                StreamReader sr = new(fileInfo.FullName, Encoding.GetEncoding(1252));
+                xDoc = XDocument.Load(sr);
             }
             catch(Exception ex)
             {

--- a/Libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
+++ b/Libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 
 /*
@@ -85,7 +86,15 @@ namespace Libraries.IntelliSenseXml
 
         private void LoadFile(FileInfo fileInfo, bool printSuccess)
         {
-            xDoc = XDocument.Load(fileInfo.FullName);
+            try
+            {
+                xDoc = XDocument.Load(fileInfo.FullName);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(string.Format("Failed to load '{0}'. {1}", fileInfo.FullName, ex.ToString()));
+                return;
+            }
 
             if (TryGetAssemblyName(xDoc, fileInfo.FullName, out string? assembly))
             {

--- a/Libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
+++ b/Libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
@@ -85,11 +85,6 @@ namespace Libraries.IntelliSenseXml
 
         private void LoadFile(FileInfo fileInfo, bool printSuccess)
         {
-            if (!fileInfo.Exists)
-            {
-                throw new Exception($"The IntelliSense xml file does not exist: {fileInfo.FullName}");
-            }
-
             xDoc = XDocument.Load(fileInfo.FullName);
 
             if (TryGetAssemblyName(xDoc, fileInfo.FullName, out string? assembly))

--- a/Libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
+++ b/Libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
@@ -139,9 +139,16 @@ namespace Libraries.IntelliSenseXml
                 Log.Error($"The XDocument was null: {fileName}");
                 return true;
             }
+
             if (xDoc.Root == null)
             {
                 Log.Error($"The IntelliSense xml file does not contain a root element: {fileName}");
+                return true;
+            }
+
+            if (xDoc.Root.Name == "linker" || xDoc.Root.Name == "FileList")
+            {
+                // This is a linker suppression file or a framework list
                 return true;
             }
 

--- a/Libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
+++ b/Libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
@@ -92,7 +92,7 @@ namespace Libraries.IntelliSenseXml
             }
             catch (Exception ex)
             {
-                Log.Error(string.Format("Failed to load '{0}'. {1}", fileInfo.FullName, ex.ToString()));
+                Log.Error($"Failed to load '{fileInfo.FullName}'. {ex}");
                 return;
             }
 


### PR DESCRIPTION
Remove expensive file existence checks - it will throw if they don't exist.
Read docs xml files in the correct codepage (it chokes eg on Char.xml otherwise). We already save in 1252.
Include file path when failing to read/write the XML.