### PR TITLE
Speed up execution by offloading logging

### DIFF
--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -21,7 +21,7 @@ namespace Libraries
             StringBuilder combined = new(65_536);
 
             bool unwrittenBlob = false;
-            (ConsoleColor color, string msg, object[]? args) blob = new ((ConsoleColor)(-1), "", null); // compiler can't figure out we won't use this
+            (ConsoleColor color, string msg, object[]? args) blob = new((ConsoleColor)(-1), "", null); // compiler can't figure out we won't use this
 
             Stopwatch stopwatch = Stopwatch.StartNew();
 

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 using System.Threading.Channels;
 using System.Threading.Tasks;

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics;
 using System.Text;
 using System.Threading.Channels;
+using System.Threading.Tasks;
 
 namespace Libraries
 {

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -49,7 +49,6 @@ namespace Libraries
                     if (blob.args == null)
                     {
                         combined.Append(blob.msg);
-
                     }
                     else
                     {

--- a/Libraries/ToTripleSlashPorter.cs
+++ b/Libraries/ToTripleSlashPorter.cs
@@ -186,9 +186,8 @@ namespace Libraries
                     Log.Info(false, $"Symbol '{symbol.Name}' not found in locations of project '{path}'.");
                     if (n < symbol.Locations.Count())
                     {
-                        Log.Info(false, " Trying the next location...");
+                        Log.Info(true, " Trying the next location...");
                     }
-                    Console.WriteLine();
                 }
                 n++;
             }
@@ -245,9 +244,8 @@ namespace Libraries
                     Log.Info(false, $"Symbol for '{docsType.FullName}' not found in referenced project '{projectPath}'.");
                     if (n < projectReferences.Count())
                     {
-                        Log.Info(false, $" Trying the next project...");
+                        Log.Info(true, $" Trying the next project...");
                     }
-                    Console.WriteLine();
                 }
                 n++;
             }

--- a/Program/DocsPortingTool.cs
+++ b/Program/DocsPortingTool.cs
@@ -6,8 +6,9 @@ namespace DocsPortingTool
 {
     class DocsPortingTool
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
+            Task loggingTask = Log.StartAsync();
             Configuration config = Configuration.GetCLIArgumentsForDocsPortingTool(args);
             switch (config.Direction)
             {
@@ -25,6 +26,9 @@ namespace DocsPortingTool
                 default:
                     throw new ArgumentOutOfRangeException($"Unrecognized porting direction: {config.Direction}");
             }
+
+            Log.Finished();
+            await loggingTask;
         }
     }
 }

--- a/Program/DocsPortingTool.cs
+++ b/Program/DocsPortingTool.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using Libraries;
 using System;
+using System.Threading.Tasks;
 
 namespace DocsPortingTool
 {


### PR DESCRIPTION
Move console writes to a separate thread.
On that thread, batch the calls to console. 
Don't continue batching if the color changes.
Don't continue batching if it's been over a second. [Note, this isn't perfect; if another message doesn't come in for a while, it will wait. But it will never fail to write.]
Add logging to a file, since a large run will exhaust the console buffer.

With these changes, a small run was sped up from about 10-11 sec to 7 sec. When running over the whole tree, it can save minutes.

@stephentoub this is my first time using DataFlow blocks. Does it seem reasonable?

