### PR TITLE
Change lists to dictionaries

### DIFF
--- a/Libraries/Docs/DocsCommentsContainer.cs
+++ b/Libraries/Docs/DocsCommentsContainer.cs
@@ -14,8 +14,8 @@ namespace Libraries.Docs
 
         private XDocument? xDoc = null;
 
-        public readonly List<DocsType> Types = new List<DocsType>();
-        public readonly List<DocsMember> Members = new List<DocsMember>();
+        public readonly Dictionary<string, DocsType> Types = new();
+        public readonly Dictionary<string, DocsMember> Members = new();
 
         public DocsCommentsContainer(Configuration config)
         {
@@ -51,7 +51,7 @@ namespace Libraries.Docs
             Encoding encoding = Encoding.GetEncoding(1252); // Preserves original xml encoding from Docs repo
 
             List<string> savedFiles = new List<string>();
-            foreach (var type in Types.Where(x => x.Changed))
+            foreach (var type in Types.Values.Where(x => x.Changed))
             {
                 Log.Warning(false, $"Saving changes for {type.FilePath}:");
 
@@ -237,7 +237,7 @@ namespace Libraries.Docs
             if (add)
             {
                 int totalMembersAdded = 0;
-                Types.Add(docsType);
+                Types.TryAdd(docsType.DocId, docsType); // is it OK this encounters duplicates?
 
                 if (XmlHelper.TryGetChildElement(xDoc.Root!, "Members", out XElement? xeMembers) && xeMembers != null)
                 {
@@ -245,7 +245,7 @@ namespace Libraries.Docs
                     {
                         DocsMember member = new DocsMember(fileInfo.FullName, docsType, xeMember);
                         totalMembersAdded++;
-                        Members.Add(member);
+                        Members.TryAdd(member.DocId, member); // is it OK this encounters duplicates?
                     }
                 }
 

--- a/Libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
+++ b/Libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
@@ -39,7 +39,7 @@ namespace Libraries.IntelliSenseXml
         private XDocument? xDoc = null;
 
         // The IntelliSense xml files do not separate types from members, like ECMA xml files do - Everything is a member.
-        public List<IntelliSenseXmlMember> Members = new List<IntelliSenseXmlMember>();
+        public Dictionary<string, IntelliSenseXmlMember> Members = new();
 
         public IntelliSenseXmlCommentsContainer(Configuration config)
         {
@@ -113,7 +113,7 @@ namespace Libraries.IntelliSenseXml
                                 !Config.ExcludedNamespaces.Any(excluded => member.Namespace.StartsWith(excluded))))
                         {
                             totalAdded++;
-                            Members.Add(member);
+                            Members.TryAdd(member.Name, member); // is it OK this encounters duplicates?
                         }
                     }
                 }

--- a/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
+++ b/Libraries/RoslynTripleSlash/TripleSlashSyntaxRewriter.cs
@@ -390,7 +390,7 @@ namespace Libraries.RoslynTripleSlash
                 string? docId = symbol.GetDocumentationCommentId();
                 if (!string.IsNullOrWhiteSpace(docId))
                 {
-                    member = DocsComments.Members.FirstOrDefault(m => m.DocId == docId);
+                    DocsComments.Members.TryGetValue(docId, out member);
                 }
             }
 
@@ -404,7 +404,7 @@ namespace Libraries.RoslynTripleSlash
             string? docId = symbol.GetDocumentationCommentId();
             if (!string.IsNullOrWhiteSpace(docId))
             {
-                type = DocsComments.Types.FirstOrDefault(t => t.DocId == docId);
+                DocsComments.Types.TryGetValue(docId, out type);
             }
 
             return type != null;

--- a/Libraries/ToDocsPorter.cs
+++ b/Libraries/ToDocsPorter.cs
@@ -61,12 +61,12 @@ namespace Libraries
         {
             Log.Info("Looking for IntelliSense xml comments that can be ported...");
 
-            foreach (DocsType dTypeToUpdate in DocsComments.Types)
+            foreach (DocsType dTypeToUpdate in DocsComments.Types.Values)
             {
                 PortMissingCommentsForType(dTypeToUpdate);
             }
 
-            foreach (DocsMember dMemberToUpdate in DocsComments.Members)
+            foreach (DocsMember dMemberToUpdate in DocsComments.Members.Values)
             {
                 PortMissingCommentsForMember(dMemberToUpdate);
             }
@@ -75,8 +75,7 @@ namespace Libraries
         // Tries to find an IntelliSense xml element from which to port documentation for the specified Docs type.
         private void PortMissingCommentsForType(DocsType dTypeToUpdate)
         {
-            IntelliSenseXmlMember? tsTypeToPort = IntelliSenseXmlComments.Members.FirstOrDefault(x => x.Name == dTypeToUpdate.DocIdEscaped);
-            if (tsTypeToPort != null)
+            if (IntelliSenseXmlComments.Members.TryGetValue(dTypeToUpdate.DocIdEscaped, out IntelliSenseXmlMember? tsTypeToPort))
             {
                 if (tsTypeToPort.Name == dTypeToUpdate.DocIdEscaped)
                 {
@@ -98,7 +97,7 @@ namespace Libraries
         private void PortMissingCommentsForMember(DocsMember dMemberToUpdate)
         {
             string docId = dMemberToUpdate.DocIdEscaped;
-            IntelliSenseXmlMember? tsMemberToPort = IntelliSenseXmlComments.Members.FirstOrDefault(x => x.Name == docId);
+            IntelliSenseXmlComments.Members.TryGetValue(docId, out IntelliSenseXmlMember? tsMemberToPort);
             TryGetEIIMember(dMemberToUpdate, out DocsMember? interfacedMember);
 
             if (tsMemberToPort != null || interfacedMember != null)
@@ -149,7 +148,7 @@ namespace Libraries
                 string interfacedMemberDocId = member.ImplementsInterfaceMember;
                 if (!string.IsNullOrEmpty(interfacedMemberDocId))
                 {
-                    interfacedMember = DocsComments.Members.FirstOrDefault(x => x.DocId == interfacedMemberDocId);
+                    DocsComments.Members.TryGetValue(interfacedMemberDocId, out interfacedMember);
                     return interfacedMember != null;
                 }
             }
@@ -761,7 +760,7 @@ namespace Libraries
 
                 Log.Info("Undocumented APIs:");
 
-                foreach (DocsType docsType in DocsComments.Types)
+                foreach (DocsType docsType in DocsComments.Types.Values)
                 {
                     bool undocAPI = false;
                     if (docsType.Summary.IsDocsEmpty())
@@ -772,7 +771,7 @@ namespace Libraries
                     }
                 }
 
-                foreach (DocsMember member in DocsComments.Members)
+                foreach (DocsMember member in DocsComments.Members.Values)
                 {
                     bool undocMember = false;
 

--- a/Libraries/ToTripleSlashPorter.cs
+++ b/Libraries/ToTripleSlashPorter.cs
@@ -141,7 +141,7 @@ namespace Libraries
             // Load and store the main project
             ProjectInformation mainProjectInfo = GetProjectInfo(Config.CsProj!.FullName, isMono: false);
 
-            foreach (DocsType docsType in DocsComments.Types)
+            foreach (DocsType docsType in DocsComments.Types.Values)
             {
                 // If the symbol is not found in the current compilation, nothing to do - It means the Docs
                 // for APIs from an unrelated namespace were loaded for this compilation's assembly


### PR DESCRIPTION
When doing a large run, these lists become large and I noticed the O(n) scans became a hot path.

NOTE: this detected that we were previously adding entries to the lists that had the same doc ID as existing entries. The code was just finding the first. To keep that behavior i changed to TryAdd. It's not clear whether this is a bug.