### PR TITLE
Minor perf change

### DIFF
--- a/Libraries/XmlHelper.cs
+++ b/Libraries/XmlHelper.cs
@@ -130,6 +130,16 @@ namespace Libraries
             {
                 throw new Exception("A null element was passed when attempting to retrieve the nodes in plain text.");
             }
+
+            // string.Join("", element.Nodes()) is very slow.
+            //
+            // The following is twice as fast (although still slow)
+            // but does not produce the same spacing. That may be OK.
+            //
+            //using var reader = element.CreateReader();
+            //reader.MoveToContent();
+            //return reader.ReadInnerXml().Trim();
+
             return string.Join("", element.Nodes()).Trim();
         }
 

--- a/Libraries/XmlHelper.cs
+++ b/Libraries/XmlHelper.cs
@@ -239,13 +239,9 @@ namespace Libraries
 
         private static string RemoveUndesiredEndlines(string value)
         {
-            Regex regex = new Regex(@"((?'undesiredEndlinePrefix'[^\.\:])(\r\n)+[ \t]*)");
-            string newValue = value;
-            if (regex.IsMatch(value))
-            {
-                newValue = regex.Replace(value, @"${undesiredEndlinePrefix} ");
-            }
-            return newValue.Trim();
+            value = Regex.Replace(value, @"((?'undesiredEndlinePrefix'[^\.\:])(\r\n)+[ \t]*)", @"${undesiredEndlinePrefix} ");
+
+            return value.Trim();
         }
 
         private static string SubstituteRemarksRegexPatterns(string value)


### PR DESCRIPTION
Noticed it was doing a match twice. I believe this showed up in the profile but I can't claim it was much.

Also added a note about a true bottleneck. In a large run, `string.Join("", element.Nodes())` is taking up to 50% of the time. I experimented with the commented out code, which is significantly faster but still a bottleneck. however, the spacing is slightly different (better, I think) and I don't know enough about whether it matters.