### PR TITLE
Detect <returns> in delegate types.

### DIFF
--- a/Libraries/Docs/DocsAPI.cs
+++ b/Libraries/Docs/DocsAPI.cs
@@ -182,6 +182,8 @@ namespace Libraries.Docs
         }
 
         public abstract string Summary { get; set; }
+        public abstract string ReturnType { get; }
+        public abstract string Returns { get; set; }
 
         public abstract string Remarks { get; set; }
 

--- a/Libraries/Docs/DocsMember.cs
+++ b/Libraries/Docs/DocsMember.cs
@@ -88,7 +88,7 @@ namespace Libraries.Docs
             }
         }
 
-        public string ReturnType
+        public override string ReturnType
         {
             get
             {
@@ -101,7 +101,7 @@ namespace Libraries.Docs
             }
         }
 
-        public string Returns
+        public override string Returns
         {
             get
             {

--- a/Libraries/Docs/DocsType.cs
+++ b/Libraries/Docs/DocsType.cs
@@ -202,6 +202,44 @@ namespace Libraries.Docs
             }
         }
 
+        /// <summary>
+        /// Only available when the type is a delegate.
+        /// </summary>
+        public override string ReturnType
+        {
+            get
+            {
+                XElement? xeReturnValue = XERoot.Element("ReturnValue");
+                if (xeReturnValue != null)
+                {
+                    return XmlHelper.GetChildElementValue(xeReturnValue, "ReturnType");
+                }
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Only available when the type is a delegate.
+        /// </summary>
+        public override string Returns
+        {
+            get
+            {
+                return (ReturnType != "System.Void") ? GetNodesInPlainText("returns") : string.Empty;
+            }
+            set
+            {
+                if (ReturnType != "System.Void")
+                {
+                    SaveFormattedAsXml("returns", value, addIfMissing: false);
+                }
+                else
+                {
+                    Log.Warning($"Attempted to save a returns item for a method that returns System.Void: {DocIdEscaped}");
+                }
+            }
+        }
+
         public override string Remarks
         {
             get

--- a/Libraries/Docs/IDocsAPI.cs
+++ b/Libraries/Docs/IDocsAPI.cs
@@ -15,6 +15,8 @@ namespace Libraries.Docs
         public abstract List<DocsTypeParameter> TypeParameters { get; }
         public abstract List<DocsTypeParam> TypeParams { get; }
         public abstract string Summary { get; set; }
+        public abstract string ReturnType { get; }
+        public abstract string Returns { get; set; }
         public abstract string Remarks { get; set; }
         public abstract DocsParam SaveParam(XElement xeCoreFXParam);
         public abstract DocsTypeParam AddTypeParam(string name, string value);

--- a/Libraries/ToDocsPorter.cs
+++ b/Libraries/ToDocsPorter.cs
@@ -83,6 +83,10 @@ namespace Libraries
                     TryPortMissingRemarksForAPI(dTypeToUpdate, tsTypeToPort, null, skipInterfaceRemarks: true);
                     TryPortMissingParamsForAPI(dTypeToUpdate, tsTypeToPort, null); // Some types, like delegates, have params
                     TryPortMissingTypeParamsForAPI(dTypeToUpdate, tsTypeToPort, null); // Type names ending with <T> have TypeParams
+                    if (dTypeToUpdate.BaseTypeName == "System.Delegate")
+                    {
+                        TryPortMissingMethodForMember(dTypeToUpdate, tsTypeToPort, null);
+                    }
                 }
 
                 if (dTypeToUpdate.Changed)
@@ -512,7 +516,7 @@ namespace Libraries
         }
 
         // Tries to document the passed method.
-        private void TryPortMissingMethodForMember(DocsMember dMemberToUpdate, IntelliSenseXmlMember? tsMemberToPort, DocsMember? interfacedMember)
+        private void TryPortMissingMethodForMember(IDocsAPI dMemberToUpdate, IntelliSenseXmlMember? tsMemberToPort, DocsMember? interfacedMember)
         {
             if (!Config.PortMemberReturns)
             {
@@ -879,12 +883,12 @@ namespace Libraries
                 Log.Success($"    - {api}");
             }
 
-            Log.Line();
-            Log.Info($"Total problematic APIs: {ProblematicAPIs.Count}");
-            foreach (string api in ProblematicAPIs)
-            {
-                Log.Warning($"    - {api}");
-            }
+            //Log.Line();
+            //Log.Info($"Total problematic APIs: {ProblematicAPIs.Count}");
+            //foreach (string api in ProblematicAPIs)
+            //{
+            //    Log.Warning($"    - {api}");
+            //}
 
             Log.Line();
             Log.Info($"Total added exceptions: {AddedExceptions.Count}");

--- a/Libraries/ToDocsPorter.cs
+++ b/Libraries/ToDocsPorter.cs
@@ -883,12 +883,12 @@ namespace Libraries
                 Log.Success($"    - {api}");
             }
 
-            //Log.Line();
-            //Log.Info($"Total problematic APIs: {ProblematicAPIs.Count}");
-            //foreach (string api in ProblematicAPIs)
-            //{
-            //    Log.Warning($"    - {api}");
-            //}
+            Log.Line();
+            Log.Info($"Total problematic APIs: {ProblematicAPIs.Count}");
+            foreach (string api in ProblematicAPIs)
+            {
+                Log.Warning($"    - {api}");
+            }
 
             Log.Line();
             Log.Info($"Total added exceptions: {AddedExceptions.Count}");


### PR DESCRIPTION
Delegates can have return values, but return values were only being detected in members, not in types (and delegates are types).

Example of an API that was not getting its return value ported:

https://github.com/dotnet/dotnet-api-docs/blob/net6-rc1/xml/System.Runtime.InteropServices.ObjectiveC/ObjectiveCMarshal+UnhandledExceptionPropagationHandler.xml#L21

cc @jeffhandley @aaronrobinsonmsft