### PR TITLE
Various fixes

### DIFF
--- a/Libraries/Configuration.cs
+++ b/Libraries/Configuration.cs
@@ -77,7 +77,7 @@ namespace Libraries
         public PortingDirection Direction { get; set; } = PortingDirection.ToDocs;
         public List<DirectoryInfo> DirsIntelliSense { get; } = new List<DirectoryInfo>();
         public List<DirectoryInfo> DirsDocsXml { get; } = new List<DirectoryInfo>();
-        public bool DisablePrompts { get; set; } = false;
+        public bool DisablePrompts { get; set; } = true;
         public int ExceptionCollisionThreshold { get; set; } = 70;
         public HashSet<string> ExcludedAssemblies { get; } = new HashSet<string>();
         public HashSet<string> ExcludedNamespaces { get; } = new HashSet<string>();

--- a/Libraries/Configuration.cs
+++ b/Libraries/Configuration.cs
@@ -43,6 +43,7 @@ namespace Libraries
             PortTypeRemarks,
             PortTypeSummaries,
             PortTypeTypeParams, // TypeParams of a Type
+            PrintSummaryDetails,
             PrintUndoc,
             Save,
             SkipInterfaceImplementations,
@@ -103,6 +104,7 @@ namespace Libraries
         /// TypeParams of a Type.
         /// </summary>
         public bool PortTypeTypeParams { get; set; } = true;
+        public bool PrintSummaryDetails { get; set; } = false;
         public bool PrintUndoc { get; set; } = false;
         public bool Save { get; set; } = false;
         public bool SkipInterfaceImplementations { get; set; } = false;
@@ -462,6 +464,10 @@ namespace Libraries
                                     mode = Mode.PortTypeTypeParams;
                                     break;
 
+                                case "-PRINTSUMMARYDETAILS":
+                                    mode = Mode.PrintSummaryDetails;
+                                    break;
+
                                 case "-PRINTUNDOC":
                                     mode = Mode.PrintUndoc;
                                     break;
@@ -586,6 +592,13 @@ namespace Libraries
                     case Mode.PortTypeTypeParams: // TypeParams of a Type
                         {
                             config.PortTypeTypeParams = ParseOrExit(arg, "Port Type TypeParams");
+                            mode = Mode.Initial;
+                            break;
+                        }
+
+                    case Mode.PrintSummaryDetails:
+                        {
+                            config.PrintSummaryDetails = ParseOrExit(arg, "Print summary details");
                             mode = Mode.Initial;
                             break;
                         }

--- a/Libraries/Configuration.cs
+++ b/Libraries/Configuration.cs
@@ -116,7 +116,7 @@ namespace Libraries
 
             if (args == null || args.Length == 0)
             {
-                Log.PrintHelpAndError("No arguments passed to the executable.");
+                Log.ErrorAndExit("No arguments passed to the executable.");
             }
 
             Configuration config = new Configuration();
@@ -235,7 +235,7 @@ namespace Libraries
                             }
                             else
                             {
-                                Log.PrintHelpAndError("You must specify at least one assembly.");
+                                Log.ErrorAndExit("You must specify at least one assembly.");
                             }
 
                             mode = Mode.Initial;
@@ -257,7 +257,7 @@ namespace Libraries
                             }
                             else
                             {
-                                Log.PrintHelpAndError("You must specify at least one namespace.");
+                                Log.ErrorAndExit("You must specify at least one namespace.");
                             }
 
                             mode = Mode.Initial;
@@ -279,7 +279,7 @@ namespace Libraries
                             }
                             else
                             {
-                                Log.PrintHelpAndError("You must specify at least one type name.");
+                                Log.ErrorAndExit("You must specify at least one type name.");
                             }
 
                             mode = Mode.Initial;
@@ -301,7 +301,7 @@ namespace Libraries
                             }
                             else
                             {
-                                Log.PrintHelpAndError("You must specify at least one assembly.");
+                                Log.ErrorAndExit("You must specify at least one assembly.");
                             }
 
                             mode = Mode.Initial;
@@ -323,7 +323,7 @@ namespace Libraries
                             }
                             else
                             {
-                                Log.PrintHelpAndError("You must specify at least one namespace.");
+                                Log.ErrorAndExit("You must specify at least one namespace.");
                             }
 
                             mode = Mode.Initial;
@@ -345,7 +345,7 @@ namespace Libraries
                             }
                             else
                             {
-                                Log.PrintHelpAndError("You must specify at least one type name.");
+                                Log.ErrorAndExit("You must specify at least one type name.");
                             }
 
                             mode = Mode.Initial;
@@ -479,7 +479,7 @@ namespace Libraries
                                     break;
 
                                 default:
-                                    Log.PrintHelpAndError($"Unrecognized argument: {arg}");
+                                    Log.ErrorAndExit($"Unrecognized argument: {arg}");
                                     break;
                             }
                             break;
@@ -620,7 +620,7 @@ namespace Libraries
 
                     default:
                         {
-                            Log.PrintHelpAndError("Unexpected mode.");
+                            Log.ErrorAndExit("Unexpected mode.");
                             break;
                         }
                 }
@@ -628,19 +628,19 @@ namespace Libraries
 
             if (mode != Mode.Initial)
             {
-                Log.PrintHelpAndError("You missed an argument value.");
+                Log.ErrorAndExit("You missed an argument value.");
             }
 
             if (config.DirsDocsXml == null)
             {
-                Log.PrintHelpAndError($"You must specify a path to the dotnet-api-docs xml folder using '-{nameof(Mode.Docs)}'.");
+                Log.ErrorAndExit($"You must specify a path to the dotnet-api-docs xml folder using '-{nameof(Mode.Docs)}'.");
             }
 
             if (config.Direction == PortingDirection.ToDocs)
             {
                 if (config.DirsIntelliSense.Count == 0)
                 {
-                    Log.PrintHelpAndError($"You must specify at least one IntelliSense & DLL folder using '-{nameof(Mode.IntelliSense)}'.");
+                    Log.ErrorAndExit($"You must specify at least one IntelliSense & DLL folder using '-{nameof(Mode.IntelliSense)}'.");
                 }
             }
 
@@ -648,13 +648,13 @@ namespace Libraries
             {
                 if (config.CsProj == null)
                 {
-                    Log.PrintHelpAndError($"You must specify a *.csproj file using '-{nameof(Mode.CsProj)}'.");
+                    Log.ErrorAndExit($"You must specify a *.csproj file using '-{nameof(Mode.CsProj)}'.");
                 }
             }
 
             if (config.IncludedAssemblies.Count == 0)
             {
-                Log.PrintHelpAndError($"You must specify at least one assembly with {nameof(IncludedAssemblies)}.");
+                Log.ErrorAndExit($"You must specify at least one assembly with {nameof(IncludedAssemblies)}.");
             }
 
             return config;

--- a/Libraries/Docs/DocsCommentsContainer.cs
+++ b/Libraries/Docs/DocsCommentsContainer.cs
@@ -52,7 +52,7 @@ namespace Libraries.Docs
             List<string> savedFiles = new();
             foreach (var type in Types.Values.Where(x => x.Changed))
             {
-                Log.Warning(false, $"Saving changes for {type.FilePath}:");
+                Log.Info(false, $"Saving changes for {type.FilePath} ... ");
 
                 try
                 {
@@ -82,7 +82,6 @@ namespace Libraries.Docs
                 catch (Exception e)
                 {
                     Log.Error("Failed to write to {0}. {1}", type.FilePath, e.Message);
-                    Log.Line();
                     Log.Error(e.StackTrace ?? string.Empty);
                     if (e.InnerException != null)
                     {
@@ -92,8 +91,6 @@ namespace Libraries.Docs
                         Log.Error(e.InnerException.StackTrace ?? string.Empty);
                     }
                 }
-
-                Log.Line();
             }
         }
 

--- a/Libraries/Docs/DocsCommentsContainer.cs
+++ b/Libraries/Docs/DocsCommentsContainer.cs
@@ -47,8 +47,6 @@ namespace Libraries.Docs
                 return;
             }
 
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-
             List<string> savedFiles = new();
             foreach (var type in Types.Values.Where(x => x.Changed))
             {
@@ -165,16 +163,17 @@ namespace Libraries.Docs
 
         private void LoadFile(FileInfo fileInfo)
         {
-            Encoding encoding;
+            Encoding? encoding = null;
             try
             {
-                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-                using (StreamReader sr = new(fileInfo.FullName, detectEncodingFromByteOrderMarks: true))
+                var utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                var utf8Bom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+                using (StreamReader sr = new(fileInfo.FullName, utf8NoBom, detectEncodingFromByteOrderMarks: true))
                 {
                     xDoc = XDocument.Load(sr);
-                    // Fall back to the most common codepage used in dotnet-api-docs xml files
-                    encoding = sr.CurrentEncoding ?? Encoding.GetEncoding(1252);
+                    encoding = sr.CurrentEncoding;
                 }
+
             }
             catch(Exception ex)
             {

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -438,6 +438,11 @@ Options:
                                                     Usage example:
                                                         -PortTypeTypeParams false
 
+    -PrintSummaryDetails        bool            Default is false (does not print summary details).
+                                                Prints the list of APIs that got modified by the tool.
+                                                    Usage example:
+                                                        -PrintSummaryDetails true
+
     -PrintUndoc                 bool            Default is false (prints a basic summary).
                                                 Prints a detailed summary of all the docs APIs that are undocumented.
                                                     Usage example:

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -10,88 +10,8 @@ namespace Libraries
 {
     public static class Log
     {
-        //private static Channel<(ConsoleColor, string, object[]?)> channel = Channel.CreateUnbounded<(ConsoleColor, string, object[]?)>();
-
-        //public static async Task StartAsync()
-        //{
-        //    using FileStream fs = new(Path.GetTempFileName(), FileMode.Open);
-        //    using StreamWriter sw = new(fs);
-
-        //    ConsoleColor initialForeground = Console.ForegroundColor;
-        //    ConsoleColor foreground = initialForeground; // cheaper than reading it each time
-
-        //    StringBuilder combined = new(65_536);
-
-        //    bool unwrittenBlob = false;
-        //    (ConsoleColor color, string msg, object[]? args) blob = new((ConsoleColor)(-1), "", null); // compiler can't figure out we won't use this
-
-        //    Stopwatch stopwatch = Stopwatch.StartNew();
-
-        //    while (await channel.Reader.WaitToReadAsync())
-        //    {
-        //        while (unwrittenBlob || await channel.Reader.WaitToReadAsync())
-        //        {
-        //            if (unwrittenBlob && foreground != blob.color)
-        //            {
-        //                Console.ForegroundColor = blob.color;
-        //                foreground = blob.color;
-        //            }
-
-        //            if (!unwrittenBlob)
-        //            {
-        //                blob = await channel.Reader.ReadAsync();
-
-        //                if (blob.color != (ConsoleColor)(-1) && foreground != blob.color)
-        //                {
-        //                    unwrittenBlob = true; // New color - emit what we have
-        //                    break;
-        //                }
-        //            }
-
-        //            if (blob.args == null)
-        //            {
-        //                combined.Append(blob.msg);
-        //            }
-        //            else
-        //            {
-        //                combined.AppendFormat(blob.msg, blob.args);
-        //            }
-
-        //            unwrittenBlob = false;
-
-        //            if (stopwatch.ElapsedMilliseconds > 1000)
-        //                break;
-        //        }
-
-        //        stopwatch.Restart();
-
-        //        Console.Write(combined);
-        //        sw.Write(combined);
-
-        //        combined = combined.Length < 65_536 ? combined.Clear() : new StringBuilder();
-        //    }
-
-        //    if (foreground != initialForeground)
-        //        Console.ForegroundColor = initialForeground;
-
-        //    Console.WriteLine("Written log to {0}", fs.Name);
-        //}
-
-        //public static void Finished()
-        //{
-        //    channel.Writer.Complete();
-        //}
-
         public static void Print(bool endline, ConsoleColor foregroundColor, string format, params object[]? args)
         {
-            //if (endline)
-            //{
-            //    channel.Writer.WriteAsync((foregroundColor, format + Environment.NewLine, args));
-            //}
-            //else
-            //{
-            //    channel.Writer.WriteAsync((foregroundColor, format, args));
-            //}
             ConsoleColor originalColor = Console.ForegroundColor;
             Console.ForegroundColor = foregroundColor;
 

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -242,15 +242,11 @@ namespace Libraries
 
         public delegate void PrintHelpFunction();
 
-        public static void PrintHelpAndError(string format, params object[]? args)
+        public static void ErrorAndExit(string format, params object[]? args)
         {
-            PrintHelp();
             Error(format, args);
-
-            if (args == null)
-                throw new Exception(format);
-            else
-                throw new Exception(string.Format(format, args));
+            Cyan("Use the -h|-help argument to view the usage instructions.");
+            Environment.Exit(-1);
         }
 
         public static void PrintHelp()

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -10,88 +10,101 @@ namespace Libraries
 {
     public static class Log
     {
-        private static Channel<(ConsoleColor, string, object[]?)> channel = Channel.CreateUnbounded<(ConsoleColor, string, object[]?)>();
+        //private static Channel<(ConsoleColor, string, object[]?)> channel = Channel.CreateUnbounded<(ConsoleColor, string, object[]?)>();
 
-        public static async Task StartAsync()
-        {
-            using FileStream fs = new(Path.GetTempFileName(), FileMode.Open);
-            using StreamWriter sw = new(fs);
+        //public static async Task StartAsync()
+        //{
+        //    using FileStream fs = new(Path.GetTempFileName(), FileMode.Open);
+        //    using StreamWriter sw = new(fs);
 
-            ConsoleColor initialForeground = Console.ForegroundColor;
-            ConsoleColor foreground = initialForeground; // cheaper than reading it each time
+        //    ConsoleColor initialForeground = Console.ForegroundColor;
+        //    ConsoleColor foreground = initialForeground; // cheaper than reading it each time
 
-            StringBuilder combined = new(65_536);
+        //    StringBuilder combined = new(65_536);
 
-            bool unwrittenBlob = false;
-            (ConsoleColor color, string msg, object[]? args) blob = new((ConsoleColor)(-1), "", null); // compiler can't figure out we won't use this
+        //    bool unwrittenBlob = false;
+        //    (ConsoleColor color, string msg, object[]? args) blob = new((ConsoleColor)(-1), "", null); // compiler can't figure out we won't use this
 
-            Stopwatch stopwatch = Stopwatch.StartNew();
+        //    Stopwatch stopwatch = Stopwatch.StartNew();
 
-            while (await channel.Reader.WaitToReadAsync())
-            {
-                while (unwrittenBlob || await channel.Reader.WaitToReadAsync())
-                {
-                    if (unwrittenBlob && foreground != blob.color)
-                    {
-                        Console.ForegroundColor = blob.color;
-                        foreground = blob.color;
-                    }
+        //    while (await channel.Reader.WaitToReadAsync())
+        //    {
+        //        while (unwrittenBlob || await channel.Reader.WaitToReadAsync())
+        //        {
+        //            if (unwrittenBlob && foreground != blob.color)
+        //            {
+        //                Console.ForegroundColor = blob.color;
+        //                foreground = blob.color;
+        //            }
 
-                    if (!unwrittenBlob)
-                    {
-                        blob = await channel.Reader.ReadAsync();
+        //            if (!unwrittenBlob)
+        //            {
+        //                blob = await channel.Reader.ReadAsync();
 
-                        if (blob.color != (ConsoleColor)(-1) && foreground != blob.color)
-                        {
-                            unwrittenBlob = true; // New color - emit what we have
-                            break;
-                        }
-                    }
+        //                if (blob.color != (ConsoleColor)(-1) && foreground != blob.color)
+        //                {
+        //                    unwrittenBlob = true; // New color - emit what we have
+        //                    break;
+        //                }
+        //            }
 
-                    if (blob.args == null)
-                    {
-                        combined.Append(blob.msg);
-                    }
-                    else
-                    {
-                        combined.AppendFormat(blob.msg, blob.args);
-                    }
+        //            if (blob.args == null)
+        //            {
+        //                combined.Append(blob.msg);
+        //            }
+        //            else
+        //            {
+        //                combined.AppendFormat(blob.msg, blob.args);
+        //            }
 
-                    unwrittenBlob = false;
+        //            unwrittenBlob = false;
 
-                    if (stopwatch.ElapsedMilliseconds > 1000)
-                        break;
-                }
+        //            if (stopwatch.ElapsedMilliseconds > 1000)
+        //                break;
+        //        }
 
-                stopwatch.Restart();
+        //        stopwatch.Restart();
 
-                Console.Write(combined);
-                sw.Write(combined);
+        //        Console.Write(combined);
+        //        sw.Write(combined);
 
-                combined = combined.Length < 65_536 ? combined.Clear() : new StringBuilder();
-            }
+        //        combined = combined.Length < 65_536 ? combined.Clear() : new StringBuilder();
+        //    }
 
-            if (foreground != initialForeground)
-                Console.ForegroundColor = initialForeground;
+        //    if (foreground != initialForeground)
+        //        Console.ForegroundColor = initialForeground;
 
-            Console.WriteLine("Written log to {0}", fs.Name);
-        }
+        //    Console.WriteLine("Written log to {0}", fs.Name);
+        //}
 
-        public static void Finished()
-        {
-            channel.Writer.Complete();
-        }
+        //public static void Finished()
+        //{
+        //    channel.Writer.Complete();
+        //}
 
         public static void Print(bool endline, ConsoleColor foregroundColor, string format, params object[]? args)
         {
+            //if (endline)
+            //{
+            //    channel.Writer.WriteAsync((foregroundColor, format + Environment.NewLine, args));
+            //}
+            //else
+            //{
+            //    channel.Writer.WriteAsync((foregroundColor, format, args));
+            //}
+            ConsoleColor originalColor = Console.ForegroundColor;
+            Console.ForegroundColor = foregroundColor;
+
+            string msg = args != null ? (args.Length > 0 ? string.Format(format, args) : format) : format;
             if (endline)
             {
-                channel.Writer.WriteAsync((foregroundColor, format + Environment.NewLine, args));
+                Console.WriteLine(msg);
             }
             else
             {
-                channel.Writer.WriteAsync((foregroundColor, format, args));
+                Console.Write(msg);
             }
+            Console.ForegroundColor = originalColor;
         }
 
         public static void Info(string format)

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -332,10 +332,10 @@ Options:
                                                 Usage example:
                                                     -Direction ToTripleSlash
 
-    -DisablePrompts         bool                Default is false (prompts are disabled).
+    -DisablePrompts         bool                Default is true (prompts are disabled).
                                                 Avoids prompting the user for input to correct some particular errors.
                                                     Usage example:
-                                                        -DisablePrompts true
+                                                        -DisablePrompts false
 
     -ExceptionCollisionThreshold  int (0-100)   Default is 70 (If >=70% of words collide, the string is not ported).
                                                 Decides how sensitive the detection of existing exception strings should be.

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -237,7 +237,7 @@ namespace Libraries
 
         public static void Line()
         {
-            Print(endline: true, (ConsoleColor)(-1), "", null);
+            Print(endline: true, Console.ForegroundColor, "", null);
         }
 
         public delegate void PrintHelpFunction();

--- a/Libraries/ToDocsPorter.cs
+++ b/Libraries/ToDocsPorter.cs
@@ -211,6 +211,14 @@ namespace Libraries
                 return;
             }
 
+            if (dApiToUpdate is DocsMember member &&
+                member.ParentType.BaseTypeName == "System.Enum" &&
+                member.MemberType == "Field")
+            {
+                // Avoid porting remarks for enums, they are not allowed in dotnet-api-docs (cause build warnings)
+                return;
+            }
+
             if (dApiToUpdate.Remarks.IsDocsEmpty())
             {
                 bool isEII = false;

--- a/Libraries/ToDocsPorter.cs
+++ b/Libraries/ToDocsPorter.cs
@@ -85,7 +85,7 @@ namespace Libraries
                     TryPortMissingTypeParamsForAPI(dTypeToUpdate, tsTypeToPort, null); // Type names ending with <T> have TypeParams
                     if (dTypeToUpdate.BaseTypeName == "System.Delegate")
                     {
-                        TryPortMissingMethodForMember(dTypeToUpdate, tsTypeToPort, null);
+                        TryPortMissingReturnsForMember(dTypeToUpdate, tsTypeToPort, null);
                     }
                 }
 
@@ -119,7 +119,7 @@ namespace Libraries
                 }
                 else if (dMemberToUpdate.MemberType == "Method")
                 {
-                    TryPortMissingMethodForMember(dMemberToUpdate, tsMemberToPort, interfacedMember);
+                    TryPortMissingReturnsForMember(dMemberToUpdate, tsMemberToPort, interfacedMember);
                 }
 
                 if (dMemberToUpdate.Changed)
@@ -515,8 +515,8 @@ namespace Libraries
             }
         }
 
-        // Tries to document the passed method.
-        private void TryPortMissingMethodForMember(IDocsAPI dMemberToUpdate, IntelliSenseXmlMember? tsMemberToPort, DocsMember? interfacedMember)
+        // Tries to document the returns element of the specified API: it can be a Method Member, or a Delegate Type.
+        private void TryPortMissingReturnsForMember(IDocsAPI dMemberToUpdate, IntelliSenseXmlMember? tsMemberToPort, DocsMember? interfacedMember)
         {
             if (!Config.PortMemberReturns)
             {

--- a/Libraries/ToDocsPorter.cs
+++ b/Libraries/ToDocsPorter.cs
@@ -50,11 +50,10 @@ namespace Libraries
             }
 
             PortMissingComments();
-
+            DocsComments.Save();
             PrintUndocumentedAPIs();
             PrintSummary();
 
-            DocsComments.Save();
         }
 
         private void PortMissingComments()
@@ -315,12 +314,12 @@ namespace Libraries
                             if (tsMemberToPort.Params.Count() == 0)
                             {
                                 ProblematicAPIs.AddIfNotExists($"Param=[{dParam.Name}] in Member DocId=[{dApiToUpdate.DocId}]");
-                                Log.Warning($"  There were no IntelliSense xml comments for param '{dParam.Name}' in {dApiToUpdate.DocId}");
+                                Log.Warning($"There were no IntelliSense xml comments for param '{dParam.Name}' in {dApiToUpdate.DocId}");
                             }
                             else if (tsMemberToPort.Params.Count() != dApiToUpdate.Params.Count())
                             {
                                 ProblematicAPIs.AddIfNotExists($"Param=[{dParam.Name}] in Member DocId=[{dApiToUpdate.DocId}]");
-                                Log.Warning($"  The total number of params does not match between the IntelliSense and the Docs members: {dApiToUpdate.DocId}");
+                                Log.Warning($"The total number of params does not match between the IntelliSense and the Docs members: {dApiToUpdate.DocId}");
                             }
                             else
                             {
@@ -727,11 +726,14 @@ namespace Libraries
         /// <param name="docId">The API unique identifier.</param>
         private void PrintModifiedMember(string message, string docsFilePath, string docId)
         {
-            Log.Warning($"    File: {docsFilePath}");
-            Log.Warning($"        DocID: {docId}");
-            Log.Warning($"        {message}");
-            Log.Info("---------------------------------------------------");
-            Log.Line();
+            if (Config.PrintSummaryDetails)
+            {
+                Log.Warning($"    File: {docsFilePath}");
+                Log.Warning($"        DocID: {docId}");
+                Log.Warning($"        {message}");
+                Log.Info("---------------------------------------------------");
+                Log.Line();
+            }
         }
 
         // Prints all the undocumented APIs.
@@ -869,48 +871,65 @@ namespace Libraries
         private void PrintSummary()
         {
             Log.Line();
-            Log.Success("---------");
-            Log.Success("FINISHED!");
-            Log.Success("---------");
-
-            Log.Line();
             Log.Info($"Total modified files: {ModifiedFiles.Count}");
-            foreach (string file in ModifiedFiles)
+            if (Config.PrintSummaryDetails)
             {
-                Log.Success($"    - {file}");
+                foreach (string file in ModifiedFiles)
+                {
+                    Log.Success($"    - {file}");
+                }
+                Log.Line();
             }
 
-            Log.Line();
             Log.Info($"Total modified types: {ModifiedTypes.Count}");
-            foreach (string type in ModifiedTypes)
+            if (Config.PrintSummaryDetails)
             {
-                Log.Success($"    - {type}");
+                foreach (string type in ModifiedTypes)
+                {
+                    Log.Success($"    - {type}");
+                }
+                Log.Line();
             }
 
-            Log.Line();
             Log.Info($"Total modified APIs: {ModifiedAPIs.Count}");
-            foreach (string api in ModifiedAPIs)
+            if (Config.PrintSummaryDetails)
             {
-                Log.Success($"    - {api}");
+                foreach (string api in ModifiedAPIs)
+                {
+                    Log.Success($"    - {api}");
+                }
             }
 
             Log.Line();
             Log.Info($"Total problematic APIs: {ProblematicAPIs.Count}");
-            foreach (string api in ProblematicAPIs)
+            if (Config.PrintSummaryDetails)
             {
-                Log.Warning($"    - {api}");
+                foreach (string api in ProblematicAPIs)
+                {
+                    Log.Warning($"    - {api}");
+                }
+                Log.Line();
             }
 
-            Log.Line();
             Log.Info($"Total added exceptions: {AddedExceptions.Count}");
-            foreach (string exception in AddedExceptions)
+            if (Config.PrintSummaryDetails)
             {
-                Log.Success($"    - {exception}");
+                foreach (string exception in AddedExceptions)
+                {
+                    Log.Success($"    - {exception}");
+                }
+                Log.Line();
             }
 
-            Log.Line();
             Log.Info(false, "Total modified individual elements: ");
             Log.Success($"{TotalModifiedIndividualElements}");
+
+            Log.Line();
+            Log.Success("---------");
+            Log.Success("FINISHED!");
+            Log.Success("---------");
+            Log.Line();
+
         }
     }
 }

--- a/Libraries/ToDocsPorter.cs
+++ b/Libraries/ToDocsPorter.cs
@@ -317,6 +317,11 @@ namespace Libraries
                                 ProblematicAPIs.AddIfNotExists($"Param=[{dParam.Name}] in Member DocId=[{dApiToUpdate.DocId}]");
                                 Log.Warning($"  There were no IntelliSense xml comments for param '{dParam.Name}' in {dApiToUpdate.DocId}");
                             }
+                            else if (tsMemberToPort.Params.Count() != dApiToUpdate.Params.Count())
+                            {
+                                ProblematicAPIs.AddIfNotExists($"Param=[{dParam.Name}] in Member DocId=[{dApiToUpdate.DocId}]");
+                                Log.Warning($"  The total number of params does not match between the IntelliSense and the Docs members: {dApiToUpdate.DocId}");
+                            }
                             else
                             {
                                 created = TryPromptParam(dParam, tsMemberToPort, out IntelliSenseXmlParam? newTsParam);
@@ -628,7 +633,7 @@ namespace Libraries
                 Log.Error($"The param probably exists in code, but the exact name was not found in Docs. What would you like to do?");
                 Log.Warning("    0 - Exit program.");
                 Log.Info("    1 - Select the correct IntelliSense xml param from the existing ones.");
-                Log.Info("    2 - Ignore this param.");
+                Log.Info("    2 - Ignore this param and continue.");
                 Log.Warning("      Note:Make sure to double check the affected Docs file after the tool finishes executing.");
                 Log.Cyan(false, "Your answer [0,1,2]: ");
 
@@ -655,7 +660,8 @@ namespace Libraries
                                 {
                                     Log.Info($"IntelliSense xml params found in member '{tsMember.Name}':");
                                     Log.Warning("    0 - Exit program.");
-                                    int paramCounter = 1;
+                                    Log.Info("    1 - Ignore this param and continue.");
+                                    int paramCounter = 2;
                                     foreach (IntelliSenseXmlParam param in tsMember.Params)
                                     {
                                         Log.Info($"    {paramCounter} - {param.Name}");
@@ -679,9 +685,14 @@ namespace Libraries
                                         Log.Info("Goodbye!");
                                         Environment.Exit(0);
                                     }
+                                    else if (paramSelection == 1)
+                                    {
+                                        Log.Info("Skipping this param.");
+                                        break;
+                                    }
                                     else
                                     {
-                                        newTsParam = tsMember.Params[paramSelection - 1];
+                                        newTsParam = tsMember.Params[paramSelection - 2];
                                         Log.Success($"Selected: {newTsParam.Name}");
                                     }
                                 }

--- a/Program/DocsPortingTool.cs
+++ b/Program/DocsPortingTool.cs
@@ -7,9 +7,8 @@ namespace DocsPortingTool
 {
     class DocsPortingTool
     {
-        public static void /*async Task*/ Main(string[] args)
+        public static void Main(string[] args)
         {
-            //Task loggingTask = Log.StartAsync();
             Configuration config = Configuration.GetCLIArgumentsForDocsPortingTool(args);
             switch (config.Direction)
             {
@@ -27,9 +26,6 @@ namespace DocsPortingTool
                 default:
                     throw new ArgumentOutOfRangeException($"Unrecognized porting direction: {config.Direction}");
             }
-
-            //Log.Finished();
-            //await loggingTask;
         }
     }
 }

--- a/Program/DocsPortingTool.cs
+++ b/Program/DocsPortingTool.cs
@@ -7,9 +7,9 @@ namespace DocsPortingTool
 {
     class DocsPortingTool
     {
-        public static async Task Main(string[] args)
+        public static void /*async Task*/ Main(string[] args)
         {
-            Task loggingTask = Log.StartAsync();
+            //Task loggingTask = Log.StartAsync();
             Configuration config = Configuration.GetCLIArgumentsForDocsPortingTool(args);
             switch (config.Direction)
             {
@@ -28,8 +28,8 @@ namespace DocsPortingTool
                     throw new ArgumentOutOfRangeException($"Unrecognized porting direction: {config.Direction}");
             }
 
-            Log.Finished();
-            await loggingTask;
+            //Log.Finished();
+            //await loggingTask;
         }
     }
 }

--- a/Program/DocsPortingTool.csproj
+++ b/Program/DocsPortingTool.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <Version>3.0.1</Version>
+    <Version>3.0.2</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/Tests/PortToDocs/PortToDocsTests.cs
+++ b/Tests/PortToDocs/PortToDocsTests.cs
@@ -87,6 +87,13 @@ namespace Libraries.Tests
             PortToDocs("Exception_ExistingCref", c);
         }
 
+        [Fact]
+        // Avoid porting enum field remarks
+        public void Port_EnumRemarks()
+        {
+            PortToDocs("EnumRemarks", GetConfiguration());
+        }
+
         private static readonly string TestDataRootDir = Path.Join("..", "..", "..", "PortToDocs", "TestData");
         private static readonly string IntellisenseDir = "intellisense";
         private static readonly string XmlExpectedDir = "xml_expected";

--- a/Tests/PortToDocs/TestData/EnumRemarks/intellisense/MyAssembly/MyAssembly.xml
+++ b/Tests/PortToDocs/TestData/EnumRemarks/intellisense/MyAssembly/MyAssembly.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0"?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name="T:MyNamespace.MyEnum">
+      <summary>The summary of MyEnum.</summary>
+      <remarks>These are the enum remarks and it's fine if they are ported.</remarks>
+    </member>
+    <member name="F:MyNamespace.MyEnum.MyField">
+      <summary>The summary of MyEnum.MyField.</summary>
+      <remarks>These are field enum remarks that should not be ported.</remarks>
+    </member>
+  </members>
+</doc>

--- a/Tests/PortToDocs/TestData/EnumRemarks/xml/MyAssembly/MyType.xml
+++ b/Tests/PortToDocs/TestData/EnumRemarks/xml/MyAssembly/MyType.xml
@@ -1,0 +1,34 @@
+﻿<Type Name="MyType" FullName="MyNamespace.MyEnum">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyEnum" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyField">
+      <MemberSignature Language="DocId" Value="F:MyNamespace.MyEnum.MyField" />
+      <MemberType>Field</MemberType>
+      <Implements />
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <MemberValue>0</MemberValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/PortToDocs/TestData/EnumRemarks/xml_expected/MyAssembly/MyType.xml
+++ b/Tests/PortToDocs/TestData/EnumRemarks/xml_expected/MyAssembly/MyType.xml
@@ -1,0 +1,42 @@
+﻿<Type Name="MyType" FullName="MyNamespace.MyEnum">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyEnum" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>The summary of MyEnum.</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+These are the enum remarks and it's fine if they are ported.
+
+      ]]></format>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyField">
+      <MemberSignature Language="DocId" Value="F:MyNamespace.MyEnum.MyField" />
+      <MemberType>Field</MemberType>
+      <Implements />
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>MyNamespace.MyEnum</ReturnType>
+      </ReturnValue>
+      <MemberValue>0</MemberValue>
+      <Parameters />
+      <Docs>
+        <summary>The summary of MyEnum.MyField.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>


### PR DESCRIPTION
- The parameter prompt won't show up by default. The user will be asked for it only if they specify the cmdline argument `-DisablePrompts false`.
- Reverted the Channels code change. It was slowing the tool by a lot, and preventing some messages from getting printed.
- Enum remarks are not ported.
- Made logging less verbose. Hid it behind the `-PrintSummaryDetails true` cmdline argument.
- Fix the encoding issue causing the original encoding from getting preserved.