### PR TITLE
Add inheritdoc support

### DIFF
--- a/Libraries/Docs/DocsAPI.cs
+++ b/Libraries/Docs/DocsAPI.cs
@@ -22,6 +22,12 @@ namespace Libraries.Docs
 
         protected DocsAPI(XElement xeRoot) => XERoot = xeRoot;
 
+        public bool IsUndocumented =>
+            Summary.IsDocsEmpty() ||
+            Returns.IsDocsEmpty() ||
+            Params.Any(p => p.Value.IsDocsEmpty()) ||
+            TypeParams.Any(tp => tp.Value.IsDocsEmpty());
+
         public abstract bool Changed { get; set; }
         public string FilePath { get; set; } = string.Empty;
         public abstract string DocId { get; }
@@ -205,7 +211,7 @@ namespace Libraries.Docs
             {
                 if (_docIdEscaped == null)
                 {
-                    _docIdEscaped = DocId.Replace("<", "{").Replace(">", "}").Replace("&lt;", "{").Replace("&gt;", "}");
+                    _docIdEscaped = DocId.DocIdEscaped();
                 }
                 return _docIdEscaped;
             }

--- a/Libraries/Docs/IDocsAPI.cs
+++ b/Libraries/Docs/IDocsAPI.cs
@@ -6,6 +6,7 @@ namespace Libraries.Docs
     internal interface IDocsAPI
     {
         public abstract APIKind Kind { get; }
+        public abstract bool IsUndocumented { get; }
         public abstract bool Changed { get; set; }
         public abstract string FilePath { get; set; }
         public abstract string DocId { get; }

--- a/Libraries/Extensions.cs
+++ b/Libraries/Extensions.cs
@@ -10,7 +10,7 @@ namespace Libraries
         // Adds a string to a list of strings if the element is not there yet. The method makes sure to escape unexpected curly brackets to prevent formatting exceptions.
         public static void AddIfNotExists(this List<string> list, string element)
         {
-            string cleanedElement = element.Escaped();
+            string cleanedElement = element.DocIdEscaped();
             if (!list.Contains(cleanedElement))
             {
                 list.Add(cleanedElement);
@@ -46,7 +46,7 @@ namespace Libraries
 
         // Some API DocIDs with types contain "{" and "}" to enclose the typeparam, which causes
         // an exception to be thrown when trying to embed the string in a formatted string.
-        public static string Escaped(this string str) => str.Replace("{", "{{").Replace("}", "}}");
+        public static string DocIdEscaped(this string str) => str.Replace("{", "{{").Replace("}", "}}").Replace("<", "{").Replace(">", "}").Replace("&lt;", "{").Replace("&gt;", "}");
 
         // Checks if the passed string is considered "empty" according to the Docs repo rules.
         public static bool IsDocsEmpty(this string? s) =>

--- a/Libraries/IntelliSenseXml/IntelliSenseXmlMember.cs
+++ b/Libraries/IntelliSenseXml/IntelliSenseXmlMember.cs
@@ -9,8 +9,55 @@ namespace Libraries.IntelliSenseXml
     {
         private readonly XElement XEMember;
 
+        private XElement? _xInheritDoc = null;
+        private XElement? XInheritDoc
+        {
+            get
+            {
+                if (_xInheritDoc == null)
+                {
+                    _xInheritDoc = XEMember.Elements("inheritdoc").FirstOrDefault();
+                }
+                return _xInheritDoc;
+            }
+        }
+
         public string Assembly { get; private set; }
 
+        private string? _inheritDocCref = null;
+        public string InheritDocCrefEscaped
+        {
+            get
+            {
+                if (_inheritDocCref == null)
+                {
+                    _inheritDocCref = string.Empty;
+                    if (InheritDoc && XInheritDoc != null)
+                    {
+                        XAttribute? xInheritDocCref = XInheritDoc.Attribute("cref");
+                        if (xInheritDocCref != null)
+                        {
+                            _inheritDocCref = xInheritDocCref.Value.DocIdEscaped();
+                        }
+                    }
+                }
+                return _inheritDocCref;
+            }
+        }
+
+        private bool? _inheritDoc = null;
+        public bool InheritDoc
+        {
+            get
+            {
+                if (!_inheritDoc.HasValue)
+                {
+                    _inheritDoc = XInheritDoc != null;
+
+                }
+                return _inheritDoc.Value;
+            }
+        }
 
         private string _namespace = string.Empty;
         public string Namespace

--- a/Libraries/ToDocsPorter.cs
+++ b/Libraries/ToDocsPorter.cs
@@ -580,14 +580,14 @@ namespace Libraries
         // Tries to document the returns element of the specified API: it can be a Method Member, or a Delegate Type.
         private void TryPortMissingReturnsForMember(IDocsAPI dMemberToUpdate, string? returns, bool isEII = false)
         {
-            if (Config.PortMemberReturns && !returns.IsDocsEmpty())
+            if (Config.PortMemberReturns)
             {
                 // Bug: Sometimes a void return value shows up as not documented, skip those
                 if (dMemberToUpdate.ReturnType == "System.Void")
                 {
                     ProblematicAPIs.AddIfNotExists($"Unexpected System.Void return value in Method=[{dMemberToUpdate.DocId}]");
                 }
-                else if (!returns.IsDocsEmpty())
+                else if (dMemberToUpdate.Returns.IsDocsEmpty() && !returns.IsDocsEmpty())
                 {
                     dMemberToUpdate.Returns = returns!;
                     PrintModifiedMember("returns", dMemberToUpdate.FilePath, dMemberToUpdate.DocId, isEII);

--- a/Libraries/ToDocsPorter.cs
+++ b/Libraries/ToDocsPorter.cs
@@ -569,7 +569,7 @@ namespace Libraries
         // Tries to document the passed property.
         private void TryPortMissingPropertyForMember(DocsMember dMemberToUpdate, string? property, bool isEII = false)
         {
-            if (Config.PortMemberProperties && !property.IsDocsEmpty())
+            if (Config.PortMemberProperties && dMemberToUpdate.Value.IsDocsEmpty() && !property.IsDocsEmpty())
             {
                 dMemberToUpdate.Value = property!;
                 PrintModifiedMember("property", dMemberToUpdate.FilePath, dMemberToUpdate.DocIdEscaped, isEII);

--- a/Libraries/ToDocsPorter.cs
+++ b/Libraries/ToDocsPorter.cs
@@ -285,18 +285,22 @@ namespace Libraries
                     string cleanedInterfaceRemarks = string.Empty;
                     if (!dInterfacedMember.Remarks.Contains(Configuration.ToBeAdded))
                     {
-                        cleanedInterfaceRemarks += Environment.NewLine;
-
-                        string interfaceMemberRemarks = dInterfacedMember.Remarks.RemoveSubstrings("##Remarks", "## Remarks", "<![CDATA[", "]]>");
-                        foreach (string line in interfaceMemberRemarks.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                        string interfaceMemberRemarks = dInterfacedMember.Remarks.RemoveSubstrings("##Remarks", "## Remarks", "<![CDATA[", "]]>").Trim();
+                        string[] splitted = interfaceMemberRemarks.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                        for (int i = 0; i < splitted.Length; i++)
                         {
-                            cleanedInterfaceRemarks += Environment.NewLine + line;
+                            string line = splitted[i];
+                            cleanedInterfaceRemarks += line;
+                            if (i < splitted.Length - 1)
+                            {
+                                cleanedInterfaceRemarks += Environment.NewLine;
+                            }
                         }
                     }
 
                     // Only port the interface remarks if the user desired that
                     // Otherwise, always add the EII special message
-                    remarks = eiiMessage + (!Config.SkipInterfaceRemarks ? cleanedInterfaceRemarks : string.Empty);
+                    remarks = eiiMessage + (!Config.SkipInterfaceRemarks ? Environment.NewLine + Environment.NewLine + cleanedInterfaceRemarks : string.Empty);
 
                     isEII = true;
                 }

--- a/Libraries/XmlHelper.cs
+++ b/Libraries/XmlHelper.cs
@@ -156,7 +156,7 @@ namespace Libraries
             XElement xeFormat = new XElement("format");
 
             string updatedValue = SubstituteRemarksRegexPatterns(newValue);
-            updatedValue = ReplaceMarkdownPatterns(updatedValue);
+            updatedValue = ReplaceMarkdownPatterns(updatedValue).Trim();
 
             string remarksTitle = string.Empty;
             if (!updatedValue.Contains("## Remarks"))

--- a/Program/DocsPortingTool.csproj
+++ b/Program/DocsPortingTool.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <Version>3.0.3</Version>
+    <Version>3.0.4</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/Tests/PortToDocs/PortToDocsTests.cs
+++ b/Tests/PortToDocs/PortToDocsTests.cs
@@ -37,8 +37,7 @@ namespace Libraries.Tests
         {
             PortToDocs("AssemblyAndNamespaceDifferent",
                        GetConfiguration(),
-                       assemblyName: "MyAssembly",
-                       namespaceName: "MyNamespace");
+                       namespaceNames: new[] { TestData.TestNamespace});
         }
 
         [Fact]
@@ -94,6 +93,16 @@ namespace Libraries.Tests
             PortToDocs("EnumRemarks", GetConfiguration());
         }
 
+        [Fact]
+        // When the inheritdoc label is found, look for the parent type's documentation.
+        // The parent type is located in a different assembly.
+        public void Port_InheritDoc()
+        {
+            PortToDocs("InheritDoc",
+                       GetConfiguration(),
+                       assemblyNames: new[] { TestData.TestAssembly, "System" });
+        }
+
         private static readonly string TestDataRootDir = Path.Join("..", "..", "..", "PortToDocs", "TestData");
         private static readonly string IntellisenseDir = "intellisense";
         private static readonly string XmlExpectedDir = "xml_expected";
@@ -146,12 +155,15 @@ namespace Libraries.Tests
                 SkipInterfaceRemarks = skipInterfaceRemarks
             };
 
-        private static void PortToDocs(
+    private static void PortToDocs(
             string testName,
             Configuration c,
-            string assemblyName = TestData.TestAssembly,
-            string namespaceName = null) // Most namespaces have the same assembly name
+            string[] assemblyNames = null,
+            string[] namespaceNames = null) // Most namespaces have the same assembly name
         {
+            assemblyNames ??= new string[] { TestData.TestAssembly };
+            namespaceNames ??= Array.Empty<string>();
+
             using TestDirectory testDirectory = new();
 
             string targetDir = Path.Join(testDirectory.FullPath, testName);
@@ -161,9 +173,12 @@ namespace Libraries.Tests
 
             DirectoryRecursiveCopy(sourceDir, targetDir);
 
-            c.IncludedAssemblies.Add(assemblyName);
+            foreach (string assemblyName in assemblyNames)
+            {
+                c.IncludedAssemblies.Add(assemblyName);
+            }
 
-            if (!string.IsNullOrEmpty(namespaceName))
+            foreach (string namespaceName in namespaceNames)
             {
                 c.IncludedNamespaces.Add(namespaceName);
             }

--- a/Tests/PortToDocs/TestData/InheritDoc/intellisense/MyAssembly/MyAssembly.xml
+++ b/Tests/PortToDocs/TestData/InheritDoc/intellisense/MyAssembly/MyAssembly.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0"?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name="T:MyNamespace.MyType">
+      <inheritdoc/>
+    </member>
+    <member name="M:MyNamespace.MyType.MyMethod">
+      <inheritdoc cref="M:System.MyParentType.MyMethod"/>
+    </member>
+  </members>
+</doc>

--- a/Tests/PortToDocs/TestData/InheritDoc/intellisense/System/System.xml
+++ b/Tests/PortToDocs/TestData/InheritDoc/intellisense/System/System.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0"?>
+<doc>
+  <assembly>
+    <name>System</name>
+  </assembly>
+  <members>
+    <member name="T:System.MyParentType">
+      <summary>This is the summary of the MyParentType class.</summary>
+      <remarks>These are the remarks of the MyParentType class.</remarks>
+    </member>
+    <member name="M:System.MyParentType.MyMethod">
+      <summary>This is the summary of the MyParentType.MyMethod method.</summary>
+      <remarks>These are the remarks of the MyParentType.MyMethod method.</remarks>
+    </member>
+  </members>
+</doc>

--- a/Tests/PortToDocs/TestData/InheritDoc/xml/MyAssembly/MyType.xml
+++ b/Tests/PortToDocs/TestData/InheritDoc/xml/MyAssembly/MyType.xml
@@ -1,0 +1,34 @@
+﻿<Type Name="MyType" FullName="MyNamespace.MyType">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyType" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.MyParentType</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyMethod">
+      <MemberSignature Language="DocId" Value="M:MyNamespace.MyType.MyMethod" />
+      <MemberType>Method</MemberType>
+      <Implements />
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/PortToDocs/TestData/InheritDoc/xml/System/MyParentType.xml
+++ b/Tests/PortToDocs/TestData/InheritDoc/xml/System/MyParentType.xml
@@ -1,0 +1,34 @@
+﻿<Type Name="MyParentType" FullName="System.MyParentType">
+  <TypeSignature Language="DocId" Value="T:System.MyParentType" />
+  <AssemblyInfo>
+    <AssemblyName>System</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.MyParentType</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyMethod">
+      <MemberSignature Language="DocId" Value="M:System.MyParentType.MyMethod" />
+      <MemberType>Method</MemberType>
+      <Implements />
+      <AssemblyInfo>
+        <AssemblyName>System</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/PortToDocs/TestData/InheritDoc/xml_expected/MyAssembly/MyType.xml
+++ b/Tests/PortToDocs/TestData/InheritDoc/xml_expected/MyAssembly/MyType.xml
@@ -1,0 +1,50 @@
+﻿<Type Name="MyType" FullName="MyNamespace.MyType">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyType" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.MyParentType</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>This is the summary of the MyParentType class.</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+These are the remarks of the MyParentType class.
+
+      ]]></format>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyMethod">
+      <MemberSignature Language="DocId" Value="M:MyNamespace.MyType.MyMethod" />
+      <MemberType>Method</MemberType>
+      <Implements />
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>This is the summary of the MyParentType.MyMethod method.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+These are the remarks of the MyParentType.MyMethod method.
+
+          ]]></format>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/Tests/PortToDocs/TestData/InheritDoc/xml_expected/System/MyParentType.xml
+++ b/Tests/PortToDocs/TestData/InheritDoc/xml_expected/System/MyParentType.xml
@@ -1,0 +1,50 @@
+﻿<Type Name="MyParentType" FullName="System.MyParentType">
+  <TypeSignature Language="DocId" Value="T:System.MyParentType" />
+  <AssemblyInfo>
+    <AssemblyName>System</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.MyParentType</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>This is the summary of the MyParentType class.</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+These are the remarks of the MyParentType class.
+
+      ]]></format>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="MyMethod">
+      <MemberSignature Language="DocId" Value="M:System.MyParentType.MyMethod" />
+      <MemberType>Method</MemberType>
+      <Implements />
+      <AssemblyInfo>
+        <AssemblyName>System</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>This is the summary of the MyParentType.MyMethod method.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+These are the remarks of the MyParentType.MyMethod method.
+
+          ]]></format>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>


### PR DESCRIPTION
cc @joperezr Thanks for reporting the bug.

This PR makes sure that the inheritdoc tag triggers looking for the base type and retrieving the documentation of the inherited API.