### PR TITLE
Bump .NET 6.0 version in global.json

### DIFF
--- a/Tests/PortToDocs/PortToDocsTests.cs
+++ b/Tests/PortToDocs/PortToDocsTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/PortToTripleSlash/PortToTripleSlashTestData.cs
+++ b/Tests/PortToTripleSlash/PortToTripleSlashTestData.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Xunit;
+﻿using Xunit;
 
 namespace Libraries.Tests
 {

--- a/Tests/PortToTripleSlash/PortToTripleSlashTests.cs
+++ b/Tests/PortToTripleSlash/PortToTripleSlashTests.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-using System.IO;
-using Xunit;
+﻿using Xunit;
 using Xunit.Abstractions;
 
 namespace Libraries.Tests

--- a/Tests/TestDirectory.cs
+++ b/Tests/TestDirectory.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using Xunit;
+﻿using Xunit;
 
 namespace Libraries.Tests
 {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
-    "sdk": {
-      "version": "6.0.100-preview.1.21103.13",
-      "allowPrerelease": true,
-      "rollForward": "major"
-    }
+  "sdk": {
+    "version": "6.0.100-rc.1.21411.28",
+    "allowPrerelease": true,
+    "rollForward": "major"
+  }
 }


### PR DESCRIPTION
To get rid of the CI test failure when there are missing usings.