### PR TITLE
Fix bug preventing some DocId from being properly printed/matched

### DIFF
--- a/Libraries/Docs/DocsAPI.cs
+++ b/Libraries/Docs/DocsAPI.cs
@@ -8,7 +8,6 @@ namespace Libraries.Docs
 {
     internal abstract class DocsAPI : IDocsAPI
     {
-        private string? _docIdEscaped = null;
         private List<DocsParam>? _params;
         private List<DocsParameter>? _parameters;
         private List<DocsTypeParameter>? _typeParameters;
@@ -138,7 +137,7 @@ namespace Libraries.Docs
                 {
                     if (Docs != null)
                     {
-                        _seeAlsoCrefs = Docs.Elements("seealso").Select(x => XmlHelper.GetAttributeValue(x, "cref")).ToList();
+                        _seeAlsoCrefs = Docs.Elements("seealso").Select(x => XmlHelper.GetAttributeValue(x, "cref").DocIdEscaped()).ToList();
                     }
                     else
                     {
@@ -157,7 +156,7 @@ namespace Libraries.Docs
                 {
                     if (Docs != null)
                     {
-                        _altMemberCrefs = Docs.Elements("altmember").Select(x => XmlHelper.GetAttributeValue(x, "cref")).ToList();
+                        _altMemberCrefs = Docs.Elements("altmember").Select(x => XmlHelper.GetAttributeValue(x, "cref").DocIdEscaped()).ToList();
                     }
                     else
                     {
@@ -202,18 +201,6 @@ namespace Libraries.Docs
                     _assemblyInfos = new List<DocsAssemblyInfo>();
                 }
                 return _assemblyInfos;
-            }
-        }
-
-        public string DocIdEscaped
-        {
-            get
-            {
-                if (_docIdEscaped == null)
-                {
-                    _docIdEscaped = DocId.DocIdEscaped();
-                }
-                return _docIdEscaped;
             }
         }
 

--- a/Libraries/Docs/DocsException.cs
+++ b/Libraries/Docs/DocsException.cs
@@ -18,7 +18,7 @@ namespace Libraries.Docs
         {
             get
             {
-                return XmlHelper.GetAttributeValue(XEException, "cref");
+                return XmlHelper.GetAttributeValue(XEException, "cref").DocIdEscaped();
             }
         }
 

--- a/Libraries/Docs/DocsMember.cs
+++ b/Libraries/Docs/DocsMember.cs
@@ -65,7 +65,7 @@ namespace Libraries.Docs
                         string message = string.Format("Could not find a DocId MemberSignature for '{0}'", MemberName);
                         throw new Exception(message);
                     }
-                     _docId = ms.Value;
+                     _docId = ms.Value.DocIdEscaped();
                 }
                 return _docId;
             }
@@ -115,7 +115,7 @@ namespace Libraries.Docs
                 }
                 else
                 {
-                    Log.Warning($"Attempted to save a returns item for a method that returns System.Void: {DocIdEscaped}");
+                    Log.Warning($"Attempted to save a returns item for a method that returns System.Void: {DocId}");
                 }
             }
         }
@@ -158,7 +158,7 @@ namespace Libraries.Docs
                 }
                 else
                 {
-                    Log.Warning($"Attempted to save a value element for an API that is not a property: {DocIdEscaped}");
+                    Log.Warning($"Attempted to save a value element for an API that is not a property: {DocId}");
                 }
             }
         }

--- a/Libraries/Docs/DocsType.cs
+++ b/Libraries/Docs/DocsType.cs
@@ -120,7 +120,7 @@ namespace Libraries.Docs
                         string message = $"DocId TypeSignature not found for FullName";
                         throw new Exception($"DocId TypeSignature not found for FullName");
                     }
-                    _docId = dts.Value;
+                    _docId = dts.Value.DocIdEscaped();
                 }
                 return _docId;
             }
@@ -239,7 +239,7 @@ namespace Libraries.Docs
                 }
                 else
                 {
-                    Log.Warning($"Attempted to save a returns item for a method that returns System.Void: {DocIdEscaped}");
+                    Log.Warning($"Attempted to save a returns item for a method that returns System.Void: {DocId}");
                 }
             }
         }

--- a/Libraries/Extensions.cs
+++ b/Libraries/Extensions.cs
@@ -1,8 +1,4 @@
-﻿#nullable enable
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-
-namespace Libraries
+﻿namespace Libraries
 {
     // Provides generic extension methods.
     internal static class Extensions
@@ -46,7 +42,14 @@ namespace Libraries
 
         // Some API DocIDs with types contain "{" and "}" to enclose the typeparam, which causes
         // an exception to be thrown when trying to embed the string in a formatted string.
-        public static string DocIdEscaped(this string str) => str.Replace("{", "{{").Replace("}", "}}").Replace("<", "{").Replace(">", "}").Replace("&lt;", "{").Replace("&gt;", "}");
+        public static string DocIdEscaped(this string docId) =>
+            docId
+            .Replace("{", "{{")
+            .Replace("}", "}}")
+            .Replace("<", "{{")
+            .Replace(">", "}}")
+            .Replace("&lt;", "{{")
+            .Replace("&gt;", "}}");
 
         // Checks if the passed string is considered "empty" according to the Docs repo rules.
         public static bool IsDocsEmpty(this string? s) =>

--- a/Libraries/IntelliSenseXml/IntelliSenseXmlMember.cs
+++ b/Libraries/IntelliSenseXml/IntelliSenseXmlMember.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 
 namespace Libraries.IntelliSenseXml
 {
@@ -25,7 +22,7 @@ namespace Libraries.IntelliSenseXml
         public string Assembly { get; private set; }
 
         private string? _inheritDocCref = null;
-        public string InheritDocCrefEscaped
+        public string InheritDocCref
         {
             get
             {
@@ -87,7 +84,8 @@ namespace Libraries.IntelliSenseXml
             {
                 if (_name == null)
                 {
-                    _name = XmlHelper.GetAttributeValue(XEMember, "name");
+                    // The member name is a DocId
+                    _name = XmlHelper.GetAttributeValue(XEMember, "name").DocIdEscaped();
                 }
                 return _name;
             }

--- a/Libraries/ToDocsPorter.cs
+++ b/Libraries/ToDocsPorter.cs
@@ -74,7 +74,7 @@ namespace Libraries
         // Tries to find an IntelliSense xml element from which to port documentation for the specified Docs type.
         private void PortMissingCommentsForType(DocsType dTypeToUpdate)
         {
-            string docId = dTypeToUpdate.DocIdEscaped;
+            string docId = dTypeToUpdate.DocId;
             if (IntelliSenseXmlComments.Members.TryGetValue(docId, out IntelliSenseXmlMember? tsTypeToPort) && tsTypeToPort.Name == docId)
             {
                 IntelliSenseXmlMember tsActualTypeToPort = tsTypeToPort;
@@ -119,9 +119,9 @@ namespace Libraries
             string? remarks = null;
 
             // See if there is an inheritdoc cref indicating the exact member to use for docs
-            if (!string.IsNullOrEmpty(tsTypeToPort.InheritDocCrefEscaped))
+            if (!string.IsNullOrEmpty(tsTypeToPort.InheritDocCref))
             {
-                if (IntelliSenseXmlComments.Members.TryGetValue(tsTypeToPort.InheritDocCrefEscaped, out IntelliSenseXmlMember? tsInheritedMember) && tsInheritedMember != null)
+                if (IntelliSenseXmlComments.Members.TryGetValue(tsTypeToPort.InheritDocCref, out IntelliSenseXmlMember? tsInheritedMember) && tsInheritedMember != null)
                 {
                     summary = tsInheritedMember.Summary;
                     returns = tsInheritedMember.Returns;
@@ -160,7 +160,7 @@ namespace Libraries
             string? returns = null;
             bool isEII = false;
 
-            if (IntelliSenseXmlComments.Members.TryGetValue(dMemberToUpdate.DocIdEscaped, out IntelliSenseXmlMember? tsMemberToPort) && tsMemberToPort != null)
+            if (IntelliSenseXmlComments.Members.TryGetValue(dMemberToUpdate.DocId, out IntelliSenseXmlMember? tsMemberToPort) && tsMemberToPort != null)
             {
                 // Rare case where the base type or interface docs should be used
                 if (tsMemberToPort.InheritDoc)
@@ -213,8 +213,8 @@ namespace Libraries
             string? property = null;
 
             // See if there is an inheritdoc cref indicating the exact member to use for docs
-            if (!string.IsNullOrEmpty(tsMemberToPort.InheritDocCrefEscaped) &&
-                IntelliSenseXmlComments.Members.TryGetValue(tsMemberToPort.InheritDocCrefEscaped, out IntelliSenseXmlMember? tsInheritedMember) && tsInheritedMember != null)
+            if (!string.IsNullOrEmpty(tsMemberToPort.InheritDocCref) &&
+                IntelliSenseXmlComments.Members.TryGetValue(tsMemberToPort.InheritDocCref, out IntelliSenseXmlMember? tsInheritedMember) && tsInheritedMember != null)
             {
                 summary = tsInheritedMember.Summary;
                 returns = isMethod ? tsInheritedMember.Returns : null;
@@ -222,18 +222,18 @@ namespace Libraries
                 property = isProperty ? GetPropertyValue(tsInheritedMember.Value, tsInheritedMember.Returns) : null;
             }
             // Look for the base type and find the member from which this one inherits
-            else if (DocsComments.Types.TryGetValue($"T:{dMemberToUpdate.ParentType.DocIdEscaped}", out DocsType? dBaseType) && dBaseType != null)
+            else if (DocsComments.Types.TryGetValue($"T:{dMemberToUpdate.ParentType.DocId}", out DocsType? dBaseType) && dBaseType != null)
             {
                 // Get all the members of the base type
                 var membersOfParentType = DocsComments.Members.Where(kvp => kvp.Value.ParentType.FullName == dBaseType.FullName);
                 if (membersOfParentType.Any())
                 {
                     DocsMember? dBaseMember = null;
-                    string unprefixedDocId = dMemberToUpdate.DocIdEscaped[2..];
-                    string baseTypeDocId = dBaseType.DocIdEscaped[2..];
+                    string unprefixedDocId = dMemberToUpdate.DocId[2..];
+                    string baseTypeDocId = dBaseType.DocId[2..];
                     foreach (var kvp in membersOfParentType)
                     {
-                        string currentDocId = kvp.Value.DocIdEscaped[2..];
+                        string currentDocId = kvp.Value.DocId[2..];
                         // Replace the prefix of the base type member API with the prefix of the member API to document
                         string replacedDocId = currentDocId.Replace(baseTypeDocId, unprefixedDocId);
                         if (replacedDocId == unprefixedDocId)
@@ -274,10 +274,10 @@ namespace Libraries
             if (!dInterfacedMember.Remarks.IsDocsEmpty())
             {
                 // Only attempt to port if the member name is the same as the interfaced member docid without prefix
-                if (dMemberToUpdate.MemberName == dInterfacedMember.DocIdEscaped[2..])
+                if (dMemberToUpdate.MemberName == dInterfacedMember.DocId[2..])
                 {
-                    string dMemberToUpdateTypeDocIdNoPrefix = dMemberToUpdate.ParentType.DocIdEscaped[2..];
-                    string interfacedMemberTypeDocIdNoPrefix = dInterfacedMember.ParentType.DocIdEscaped[2..];
+                    string dMemberToUpdateTypeDocIdNoPrefix = dMemberToUpdate.ParentType.DocId[2..];
+                    string interfacedMemberTypeDocIdNoPrefix = dInterfacedMember.ParentType.DocId[2..];
 
                     // Special text for EIIs in Remarks
                     string eiiMessage = $"This member is an explicit interface member implementation. It can be used only when the <xref:{dMemberToUpdateTypeDocIdNoPrefix}> instance is cast to an <xref:{interfacedMemberTypeDocIdNoPrefix}> interface.";
@@ -572,7 +572,7 @@ namespace Libraries
             if (Config.PortMemberProperties && dMemberToUpdate.Value.IsDocsEmpty() && !property.IsDocsEmpty())
             {
                 dMemberToUpdate.Value = property!;
-                PrintModifiedMember("property", dMemberToUpdate.FilePath, dMemberToUpdate.DocIdEscaped, isEII);
+                PrintModifiedMember("property", dMemberToUpdate.FilePath, dMemberToUpdate.DocId, isEII);
                 TotalModifiedIndividualElements++;
             }
         }

--- a/Tests/PortToDocs/TestData/Basic/intellisense/MyAssembly/MyAssembly.xml
+++ b/Tests/PortToDocs/TestData/Basic/intellisense/MyAssembly/MyAssembly.xml
@@ -25,5 +25,11 @@
       <summary>This is the property summary.</summary>
       <value>This is the property value.</value>
     </member>
+    <member name="M:MyNamespace.MyType.MyTypeParamMethod``1(``0,System.Collections.Generic.IEqualityComparer{``0})">
+      <typeparam name="TValue">The typeparam of MyTypeParamMethod.</typeparam>
+      <param name="value">An element of type <typeparamref name="TValue" />.</param>
+      <param name="comparer">The equality comparer of type <typeparamref name="TValue" />.</param>
+      <summary>The signature of this method would be: <c>public void Add&lt;TValue&gt; (TValue value, System.Collections.Generic.IEqualityComparer&lt;TValue&gt; comparer);</c></summary>
+    </member>
   </members>
 </doc>

--- a/Tests/PortToDocs/TestData/Basic/xml/MyAssembly/MyType.xml
+++ b/Tests/PortToDocs/TestData/Basic/xml/MyAssembly/MyType.xml
@@ -42,12 +42,41 @@
     <Member MemberName="MyProperty">
       <MemberSignature Language="DocId" Value="P:MyNamespace.MyType.MyProperty" />
       <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
         <summary>To be added.</summary>
         <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Add&lt;TValue&gt;">
+      <MemberSignature Language="DocId" Value="M:MyNamespace.MyType.MyTypeParamMethod``1(``0,System.Collections.Generic.IEqualityComparer{``0})" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TValue" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="value" Type="TValue" />
+        <Parameter Name="comparer" Type="System.Collections.Generic.IEqualityComparer&lt;TValue&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TValue">To be added.</typeparam>
+        <param name="value">To be added.</param>
+        <param name="comparer">To be added.</param>
+        <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/Tests/PortToDocs/TestData/Basic/xml_expected/MyAssembly/MyType.xml
+++ b/Tests/PortToDocs/TestData/Basic/xml_expected/MyAssembly/MyType.xml
@@ -44,12 +44,41 @@
     <Member MemberName="MyProperty">
       <MemberSignature Language="DocId" Value="P:MyNamespace.MyType.MyProperty" />
       <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
         <summary>This is the property summary.</summary>
         <value>This is the property value.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Add&lt;TValue&gt;">
+      <MemberSignature Language="DocId" Value="M:MyNamespace.MyType.MyTypeParamMethod``1(``0,System.Collections.Generic.IEqualityComparer{``0})" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TValue" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="value" Type="TValue" />
+        <Parameter Name="comparer" Type="System.Collections.Generic.IEqualityComparer&lt;TValue&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TValue">The typeparam of MyTypeParamMethod.</typeparam>
+        <param name="value">An element of type <typeparamref name="TValue" />.</param>
+        <param name="comparer">The equality comparer of type <typeparamref name="TValue" />.</param>
+        <summary>The signature of this method would be: <c>public void Add&lt;TValue&gt; (TValue value, System.Collections.Generic.IEqualityComparer&lt;TValue&gt; comparer);</c></summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
This is due to special formatting characters being part of some docIds: `{` and `}`.

Ensure all docIds get escaped everywhere (whether they come from intellisense xmls or from docs xmls) so they can be compared correctly, and so they don't cause exceptions when attempting to print them.