### PR TITLE
Update install as tool

### DIFF
--- a/install-as-tool.ps1
+++ b/install-as-tool.ps1
@@ -8,41 +8,13 @@ $BUILD_CONFIGURATION = "Release"
 $APP_NAME = "DocsPortingTool"
 $EXE_PROJECT = "Program"
 
-Write-Output "Building $APP_NAME..."
+dotnet clean -c $BUILD_CONFIGURATION; remove-item -Recurse -ErrorAction Ignore $ARTIFACTS_DIR
 dotnet pack -c $BUILD_CONFIGURATION -o $ARTIFACTS_DIR $EXE_PROJECT
 
-# Prevent uninstalling an existing tool below if the build fails
 If ($LASTEXITCODE -ne 0)
 {
 	Write-Output "$APP_NAME will not be installed/upgraded."
 	Exit
 }
 
-$toolList = dotnet tool list --global
-# Output example when there are tools installed:
-
-#   Package Id                 Version                 Commands
-#   ------------------------------------------------------------------
-#   docsportingtool            3.0.0                   DocsPortingTool
-#   microsoft.dotnet.darc      1.1.0-beta.21458.1      darc
-
-# When there are no tools installed, the output only contains:
-
-#   Package Id                 Version                 Commands
-#   ------------------------------------------------------------------
-
-If ($toolList.Length -gt 2)
-{
-	For ($i = 2; $i -lt $toolList.Length; $i++)
-	{
-		If ($toolList[$i].ToLowerInvariant().Contains($APP_NAME.ToLowerInvariant()))
-		{
-			Write-Output "Uninstalling existing $APP_NAME instance..."
-			dotnet tool uninstall --global $APP_NAME
-			Break;
-		}
-	}
-}
-
-Write-Output "Installing $APP_NAME as a global tool..."
-dotnet tool install --global --add-source $ARTIFACTS_DIR $APP_NAME
+dotnet tool update --global --add-source $ARTIFACTS_DIR $APP_NAME

--- a/install-as-tool.ps1
+++ b/install-as-tool.ps1
@@ -9,6 +9,18 @@ $APP_NAME = "DocsPortingTool"
 $EXE_PROJECT = "Program"
 
 $toolList = dotnet tool list --global
+# Output example when there are tools installed:
+
+#   Package Id                 Version                 Commands
+#   ------------------------------------------------------------------
+#   docsportingtool            3.0.0                   DocsPortingTool
+#   microsoft.dotnet.darc      1.1.0-beta.21458.1      darc
+
+# When there are no tools installed, the output only contains:
+
+#   Package Id                 Version                 Commands
+#   ------------------------------------------------------------------
+
 If ($toolList.Length -gt 2)
 {
 	For ($i = 2; $i -lt $toolList.Length; $i++)

--- a/install-as-tool.ps1
+++ b/install-as-tool.ps1
@@ -8,6 +8,16 @@ $BUILD_CONFIGURATION = "Release"
 $APP_NAME = "DocsPortingTool"
 $EXE_PROJECT = "Program"
 
+Write-Output "Building $APP_NAME..."
+dotnet pack -c $BUILD_CONFIGURATION -o $ARTIFACTS_DIR $EXE_PROJECT
+
+# Prevent uninstalling an existing tool below if the build fails
+If ($LASTEXITCODE -ne 0)
+{
+	Write-Output "$APP_NAME will not be installed/upgraded."
+	Exit
+}
+
 $toolList = dotnet tool list --global
 # Output example when there are tools installed:
 
@@ -33,9 +43,6 @@ If ($toolList.Length -gt 2)
 		}
 	}
 }
-
-Write-Output "Building $APP_NAME..."
-dotnet pack -c $BUILD_CONFIGURATION -o $ARTIFACTS_DIR $EXE_PROJECT
 
 Write-Output "Installing $APP_NAME as a global tool..."
 dotnet tool install --global --add-source $ARTIFACTS_DIR $APP_NAME

--- a/install-as-tool.ps1
+++ b/install-as-tool.ps1
@@ -5,6 +5,25 @@ Push-Location $(Split-Path $MyInvocation.MyCommand.Path)
 
 $ARTIFACTS_DIR = "artifacts"
 $BUILD_CONFIGURATION = "Release"
+$APP_NAME = "DocsPortingTool"
+$EXE_PROJECT = "Program"
 
-dotnet pack -c $BUILD_CONFIGURATION -o $ARTIFACTS_DIR "Program"
-dotnet tool update --global --add-source $ARTIFACTS_DIR "DocsPortingTool"
+$toolList = dotnet tool list --global
+If ($toolList.Length -gt 2)
+{
+	For ($i = 2; $i -lt $toolList.Length; $i++)
+	{
+		If ($toolList[$i].ToLowerInvariant().Contains($APP_NAME.ToLowerInvariant()))
+		{
+			Write-Output "Uninstalling existing $APP_NAME instance..."
+			dotnet tool uninstall --global $APP_NAME
+			Break;
+		}
+	}
+}
+
+Write-Output "Building $APP_NAME..."
+dotnet pack -c $BUILD_CONFIGURATION -o $ARTIFACTS_DIR $EXE_PROJECT
+
+Write-Output "Installing $APP_NAME as a global tool..."
+dotnet tool install --global --add-source $ARTIFACTS_DIR $APP_NAME


### PR DESCRIPTION
@eiriktsarpalis you helped add this script. Can you please review this change?

## Purpose

Ideally, we would bump the DocsPortingTool version every time we merge a PR, but we sometimes forget (I'm guilty of this).

The `dotnet tool update` command only updates a package if the version is greater than the one installed. Unfortunately, it does not have a `-force` option to overwrite the existing package if it's the same version.

So instead, what I want to do is look for any instances of it, uninstall them, then install the tool again. And this will only be done if packing succeeds (The `dotnet` process will return `0` on success).