### PR TITLE
Trim assembly name extracted from IntelliSense xml file.

### DIFF
--- a/Libraries/IntelliSenseXml/IntelliSenseXmlMember.cs
+++ b/Libraries/IntelliSenseXml/IntelliSenseXmlMember.cs
@@ -197,7 +197,7 @@ namespace Libraries.IntelliSenseXml
             }
 
             XEMember = xeMember ?? throw new ArgumentNullException(nameof(xeMember));
-            Assembly = assembly;
+            Assembly = assembly.Trim();
         }
 
         public override string ToString()

--- a/Program/DocsPortingTool.csproj
+++ b/Program/DocsPortingTool.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <Version>3.0.5</Version>
+    <Version>3.0.6</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Winforms intellisense xml files have an assembly xml item wrapped by endlines:

```xml
<?xml version="1.0"?>
<doc>
<assembly>
<name>
Microsoft.VisualBasic.Forms
</name>
</assembly>
```

Which caused the `IntelliSenseXmlMember.Assembly` string to get extracted as `\nMicrosoft.VisualBasic.Forms\n`, preventing the files to be matched correctly.

cc @dreddy-work